### PR TITLE
add get-message proxy function

### DIFF
--- a/src/NhnToast.Sms/NhnToast.Sms.csproj
+++ b/src/NhnToast.Sms/NhnToast.Sms.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
+    <PackageReference Include="SmartFormat" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NhnToast.Sms/Triggers/GetMessage.cs
+++ b/src/NhnToast.Sms/Triggers/GetMessage.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json;
+
+using SmartFormat;
+
+namespace Toast.Sms.Verification.Triggers
+{
+    public class GetMessage
+    {
+        private readonly ILogger<GetMessage> _logger;
+
+        public GetMessage(ILogger<GetMessage> log)
+        {
+            _logger = log;
+        }
+
+        [FunctionName(nameof(GetMessage))]
+        [OpenApiOperation(operationId: "Message.Get", tags: new[] { "message" })]
+        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
+        [OpenApiParameter(name: "requestId", Type = typeof(string), In = ParameterLocation.Path, Required = true, Description = "sms sender's request ID")]
+        [OpenApiParameter(name: "recipientSeq", Type = typeof(string), In = ParameterLocation.Query, Required = true, Description = "sms sending sequence number")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(object), Description = "The OK response")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Function, "GET", Route = "message/{requestId}")] HttpRequest req, string requestId)
+        {
+            _logger.LogInformation("C# HTTP trigger function processed a request.");
+
+            var appKey = Environment.GetEnvironmentVariable("Toast__AppKey");
+            var secretKey = Environment.GetEnvironmentVariable("Toast__SecretKey");
+            var baseUrl = Environment.GetEnvironmentVariable("Toast__BaseUrl");
+            var version = Environment.GetEnvironmentVariable("Toast__Version");
+            var endpoint = Environment.GetEnvironmentVariable("Toast__Endpoints__GetMessage");
+            var options = new
+            {
+                version = version,
+                appKey = appKey,
+                requestId = requestId,
+                recipientSeq = req.Query["recipientSeq"].ToString()
+            };
+            var requestUrl = Smart.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+
+            var http = new HttpClient();
+
+            // Act
+            http.DefaultRequestHeaders.Add("X-Secret-Key", secretKey);
+            var result = await http.GetAsync(requestUrl).ConfigureAwait(false);
+
+            var payload = await result.Content.ReadAsAsync<object>().ConfigureAwait(false);
+
+
+            return new OkObjectResult(payload);
+        }
+    }
+}

--- a/src/NhnToast.Sms/Triggers/GetMessage.cs
+++ b/src/NhnToast.Sms/Triggers/GetMessage.cs
@@ -36,7 +36,7 @@ namespace Toast.Sms.Verification.Triggers
         [OpenApiParameter(name: "recipientSeq", Type = typeof(string), In = ParameterLocation.Query, Required = true, Description = "sms sending sequence number")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(object), Description = "The OK response")]
         public async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "GET", Route = "message/{requestId}")] HttpRequest req, string requestId)
+            [HttpTrigger(AuthorizationLevel.Function, "GET", Route = "messages/{requestId}")] HttpRequest req, string requestId)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 

--- a/src/NhnToast.Sms/local.settings.sample.json
+++ b/src/NhnToast.Sms/local.settings.sample.json
@@ -10,7 +10,7 @@
     "Toast__Version": "v3.0",
     "Toast__Endpoints__SendMessages": "/sms/{version}/appKeys/{appKey}/sender/sms",
     "Toast__Endpoints__ListMessages": "/sms/{version}/appKeys/{appKey}/sender/sms",
-    "Toast__Endpoints__GetMessage": "/sms/{version}/appKeys/{appKey}/sender/sms/{requestId}",
+    "Toast__Endpoints__GetMessage": "/sms/{version}/appKeys/{appKey}/sender/sms/{requestId}?recipientSeq={recipientSeq}",
     "Toast__Endpoints__ListMessageStatus": "/sms/{version}/appKeys/{appKey}/message-results?startUpdateDate={startUpdateDate}&endUpdateDate={endUpdateDate}&messageType={messageType}&pageNum={pageNum}&pageSize={pageSize}"
   }
 }

--- a/test/NhnToast.Sms.Tests/NhnToast.Sms.Tests.csproj
+++ b/test/NhnToast.Sms.Tests/NhnToast.Sms.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="SmartFormat" Version="3.0.0" />
     <PackageReference Include="WorldDomination.HttpClient.Helpers" Version="7.3.4" />
   </ItemGroup>
 

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SmartFormat;
+using WorldDomination.Net.Http;
+
+namespace Toast.Sms.Tests.Triggers
+{
+    [TestClass]
+    public class GetMessageTests
+    {
+        [DataTestMethod]
+        [DataRow(false, null, false)]
+        [DataRow(false, 1, false)]
+        [DataRow(false, null, false)]
+        [DataRow(true, 1, true)]
+        [DataRow(true, 3, true)]
+        [DataRow(true, 100, true)]
+        public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId,int? recipientSeq, bool expected)
+        {
+            // Arrange
+            var config = new ConfigurationBuilder().AddJsonFile("test.settings.json").Build();
+            var appKey = config.GetValue<string>("Toast:AppKey");
+            var secretKey = config.GetValue<string>("Toast:SecretKey");
+            var baseUrl = config.GetValue<string>("Toast:BaseUrl");
+            var version = config.GetValue<string>("Toast:Version");
+            var endpoint = config.GetValue<string>("Toast:Endpoints:GetMessage");
+            var requestId = useRequestId ? config.GetValue<string>("Toast:test:requestId") : null;
+            var options = new
+            {
+                version = version,
+                appKey = appKey,
+                requestId= requestId,
+                recipientSeq= recipientSeq
+
+            };
+            var requestUrl = Smart.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+
+            var http = new HttpClient();
+
+            // Act
+            http.DefaultRequestHeaders.Add("X-Secret-Key", secretKey);
+            var result = await http.GetAsync(requestUrl).ConfigureAwait(false);
+
+            dynamic payload = await result.Content.ReadAsAsync<object>().ConfigureAwait(false);
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            ((bool)payload.header.isSuccessful).Should().Be(expected);
+
+            result.Dispose();
+        }
+    }
+}

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -18,9 +18,8 @@ namespace Toast.Sms.Tests.Triggers
         [DataTestMethod]
         [DataRow(false, null, false)]
         [DataRow(false, 1, false)]
-        [DataRow(false, null, false)]
+        [DataRow(true, null, false)]
         [DataRow(true, 1, true)]
-        [DataRow(true, 3, true)]
         [DataRow(true, 100, true)]
         public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId,int? recipientSeq, bool expected)
         {
@@ -31,7 +30,7 @@ namespace Toast.Sms.Tests.Triggers
             var baseUrl = config.GetValue<string>("Toast:BaseUrl");
             var version = config.GetValue<string>("Toast:Version");
             var endpoint = config.GetValue<string>("Toast:Endpoints:GetMessage");
-            var requestId = useRequestId ? config.GetValue<string>("Toast:test:requestId") : null;
+            var requestId = useRequestId ? config.GetValue<string>("Toast:Examples:RequestId") : null;
             var options = new
             {
                 version = version,

--- a/test/NhnToast.Sms.Tests/test.settings.sample.json
+++ b/test/NhnToast.Sms.Tests/test.settings.sample.json
@@ -7,8 +7,11 @@
     "Endpoints": {
       "SendMessages": "/sms/{version}/appKeys/{appKey}/sender/sms",
       "ListMessages": "/sms/{version}/appKeys/{appKey}/sender/sms",
-      "GetMessage": "/sms/{version}/appKeys/{appKey}/sender/sms/{requestId}",
+      "GetMessage": "/sms/{version}/appKeys/{appKey}/sender/sms/{requestId}?recipientSeq={recipientSeq}",
       "ListMessageStatus": "/sms/{version}/appKeys/{appKey}/message-results?startUpdateDate={startUpdateDate}&endUpdateDate={endUpdateDate}&messageType={messageType}&pageNum={pageNum}&pageSize={pageSize}"
+    },
+    "Examples": {
+      "RequestId": "{requestId}"
     }
   }
 }


### PR DESCRIPTION
- NHN toast api '단문 SMS 발송단일 검색' 프록시 구현

    - 유닛 테스트 코드

    - openapi를 이용한 프록시 함수

- [reference: openapi 문서](https://github.com/Azure/azure-functions-openapi-extension/blob/main/docs/openapi-core.md#openapiparameterattribute)