### PR TITLE
Update SmartFormatter to allow case insensitivity

### DIFF
--- a/src/NhnToast.Sms/Configurations/ToastSettings.cs
+++ b/src/NhnToast.Sms/Configurations/ToastSettings.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using SmartFormat;
+using SmartFormat.Core.Settings;
 
 namespace Toast.Sms.Configurations
 {
@@ -36,8 +34,13 @@ namespace Toast.Sms.Configurations
         public virtual string Version { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="SmsSettings"/> object.
+        /// Gets or sets the <see cref="SmsEndpointSettings"/> object.
         /// </summary>
         public virtual SmsEndpointSettings Endpoints { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="SmartFormatter"/> instance.
+        /// </summary>
+        public virtual SmartFormatter Formatter { get; } = Smart.CreateDefaultSmartFormat(new SmartSettings() { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
     }
 }

--- a/src/NhnToast.Sms/Startup.cs
+++ b/src/NhnToast.Sms/Startup.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -11,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Toast.Sms.Configurations;
 
 [assembly: FunctionsStartup(typeof(Toast.Sms.Startup))]
+
 namespace Toast.Sms
 {
     public class Startup : FunctionsStartup

--- a/test/NhnToast.Sms.Tests/Configurations/ToastSettingsTests.cs
+++ b/test/NhnToast.Sms.Tests/Configurations/ToastSettingsTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Toast.Sms.Configurations;
+
+namespace Toast.Sms.Tests.Configurations
+{
+    [TestClass]
+    public class ToastSettingsTests
+    {
+        [DataTestMethod]
+        [DataRow("1.0.0", "helloworld", "/api/{version}/apps/{appKey}", "/api/1.0.0/apps/helloworld")]
+        [DataRow("1.0.0", "helloworld", "/api/{Version}/apps/{AppKey}", "/api/1.0.0/apps/helloworld")]
+        public void Given_CarmelCaseObject_When_Formatted_Then_It_Should_Return_Result(string version, string appKey, string endpoint, string expected)
+        {
+            var options = new
+            {
+                version = version,
+                appKey = appKey,
+            };
+
+            var settings = new ToastSettings();
+
+            var result = settings.Formatter.Format(endpoint, options);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("1.0.0", "helloworld", "/api/{version}/apps/{appKey}", "/api/1.0.0/apps/helloworld")]
+        [DataRow("1.0.0", "helloworld", "/api/{Version}/apps/{AppKey}", "/api/1.0.0/apps/helloworld")]
+        public void Given_CapitalCaseObject_When_Formatted_Then_It_Should_Return_Result(string version, string appKey, string endpoint, string expected)
+        {
+            var options = new
+            {
+                Version = version,
+                AppKey = appKey,
+            };
+
+            var settings = new ToastSettings();
+
+            var result = settings.Formatter.Format(endpoint, options);
+
+            result.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
This PR is:

* To allow case insensitive formatting. For example both are possible:

    ```csharp
    // all carmelCases
    var options = { version = "v3", appKey = "abc" };
    var endpoint = "/api/{version}/apps/{appKey}";

    var result = SmartFormatter.Format(endpoint, options);

    // all CapitalCases
    var options = { Version = "v3", AppKey = "abc" };
    var endpoint = "/api/{version}/apps/{appKey}";

    var result = SmartFormatter.Format(endpoint, options);
    ````