### PR TITLE
Add RequestUrlBuilder & Unit Test

### DIFF
--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -59,10 +59,10 @@ namespace Toast.Common.Builders
         {
             if (this._settings == null)
             {
-                throw new InvalidOperationException("_settings is not be null when WithQueries() is invoked");
+                throw new InvalidOperationException("Invalid ToastSettings.");
             }
 
-            var serialised = JsonConvert.SerializeObject(queries, this._settings.SerializerSetting);
+            var serialised = JsonConvert.SerializeObject(queries, this._settings.JsonFormatter.SerializerSettings);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
 
             this._queries = string.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
@@ -80,10 +80,10 @@ namespace Toast.Common.Builders
         {
             if (this._settings == null)
             {
-                throw new InvalidOperationException("_settings is not be null when WithPaths() is invoked");
+                throw new InvalidOperationException("Invalid ToastSettings.");
             }
 
-            var serialised = JsonConvert.SerializeObject(paths, this._settings.SerializerSetting);
+            var serialised = JsonConvert.SerializeObject(paths, this._settings.JsonFormatter.SerializerSettings);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
 
             this._paths = deserialised;

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -1,0 +1,165 @@
+using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Toast.Common.Configurations;
+using Toast.Common.Models;
+
+namespace Toast.Common.Builders
+{
+    /// <summary>
+    /// This represents the Builder for request URL.
+    /// </summary>
+    public class RequestUrlBuilder
+    {
+        /// <summary>
+        /// Gets or sets the Settings for RequestUrlBuilder.
+        /// </summary>
+        public ToastSettings Settings { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the BaseUrl for RequestUrlBuilder.
+        /// </summary>
+        public string BaseUrl { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the Version for RequestUrlBuilder.
+        /// </summary>
+        public string Version { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the AppKey for RequestUrlBuilder.
+        /// </summary>
+        public string AppKey { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the Endpoint for RequestUrlBuilder.
+        /// </summary>
+        public string Endpoint { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the Quries Dictionay for RequestUrlBuilder.
+        /// </summary>
+        public Dictionary<string, string> Queries { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the Paths Dictionay for RequestUrlBuilder.
+        /// </summary
+        public Dictionary<string, string> Paths { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the RequestUrl for RequestUrlBuilder.
+        /// </summary>
+        public string RequestUrl { get; private set; }
+
+
+        /// <summary>
+        /// Settings the request URL values in setting.
+        /// </summary>
+        /// <param name="settings"> instance.</param>
+        /// <param name="endpoint"> instance.</param>
+        /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
+        public RequestUrlBuilder WithSettings<T> (T settings, string endpoint) where T : ToastSettings
+        {
+            Settings = settings;
+            BaseUrl = settings.BaseUrl;
+            Version = settings.Version;
+            Endpoint = endpoint;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Settings the request URL values in header.
+        /// </summary>
+        /// <param name="headers"> <see cref="RequestHeaderModel"/> instance.</param>
+        /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
+        public RequestUrlBuilder WithHeaders(RequestHeaderModel headers)
+        {
+            AppKey = headers.AppKey;
+            
+            return this;
+        }
+
+        /// <summary>
+        /// Settings the request URL values in header.
+        /// </summary>
+        /// <param name="queries"> instance.</param>
+        /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
+        public RequestUrlBuilder WithQueries<T>(T queries)
+        {
+            try
+            {
+                var serialised = JsonConvert.SerializeObject(queries);
+                Queries = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
+            }
+            catch(Exception ex)
+            {
+                Queries = null;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Settings the request URL values in header.
+        /// </summary>
+        /// <param name="paths"> instance.</param>
+        /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
+        public RequestUrlBuilder WithPaths(string[] paths)
+        {
+            try
+            {
+                Paths = Enumerable.Range(0, paths.Length / 2).ToDictionary(i => paths[i * 2], i => paths[i * 2 + 1]);
+            }
+            catch(Exception ex)
+            {
+                Paths = null;
+            }
+            
+            
+            return this;
+        }
+
+        /// <summary>
+        /// Settings the request URL values in header.
+        /// </summary>
+        /// <returns>Returns request URL which is string type instance.</returns>
+        public string Build()
+        {
+            if (BaseUrl == null) return $"{BaseUrl}/{Endpoint.TrimStart('/')}";
+            else if (Endpoint == null) return $"{BaseUrl.TrimEnd('/')}/{Endpoint}";
+
+            Endpoint = Endpoint.Replace("{version}", Version);
+            Endpoint = Endpoint.Replace("{appKey}", AppKey);
+
+            if (Queries != null)
+            {
+                foreach (var querie in Queries)
+                {
+                    var where = querie.Key;
+
+                    where = where.Insert(0, "{");
+                    where = where.Insert(where.Length, "}");
+                    Endpoint = Endpoint.Replace(where, querie.Value);
+                }
+            }
+
+            if (Paths != null)
+            {
+                foreach (var path in Paths)
+                {
+                    var where = path.Key;
+                    where = where.Insert(0, "{");
+                    where = where.Insert(where.Length, "}");
+
+                    Endpoint = Endpoint.Replace(where, path.Value);
+                }
+            }
+
+            return $"{BaseUrl.TrimEnd('/')}/{Endpoint.TrimStart('/')}";
+        }
+    }
+}

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -107,11 +107,12 @@ namespace Toast.Common.Builders
         /// </summary>
         /// <param name="paths"> instance.</param>
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
-        public RequestUrlBuilder WithPaths(string[] paths)
+        public RequestUrlBuilder WithPaths<T>(T paths) where T : BaseRequestPaths
         {
             try
             {
-                Paths = Enumerable.Range(0, paths.Length / 2).ToDictionary(i => paths[i * 2], i => paths[i * 2 + 1]);
+                var serialised = JsonConvert.SerializeObject(paths, Settings.SerializerSsetting);
+                Paths = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
             }
             catch(Exception ex)
             {
@@ -134,29 +135,9 @@ namespace Toast.Common.Builders
             Endpoint = Endpoint.Replace("{version}", Version);
             Endpoint = Endpoint.Replace("{appKey}", AppKey);
 
-            if (Queries != null)
-            {
-                foreach (var querie in Queries)
-                {
-                    var where = querie.Key;
+            Endpoint += String.Join("&", Queries.Select(x => x.Key + "=" + x.Value).ToArray());
 
-                    where = where.Insert(0, "{");
-                    where = where.Insert(where.Length, "}");
-                    Endpoint = Endpoint.Replace(where, querie.Value);
-                }
-            }
-
-            if (Paths != null)
-            {
-                foreach (var path in Paths)
-                {
-                    var where = path.Key;
-                    where = where.Insert(0, "{");
-                    where = where.Insert(where.Length, "}");
-
-                    Endpoint = Endpoint.Replace(where, path.Value);
-                }
-            }
+            Endpoint += String.Join("&", Paths.Select(x => x.Key + "=" + x.Value).ToArray());
 
             return $"{BaseUrl.TrimEnd('/')}/{Endpoint.TrimStart('/')}";
         }

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -105,7 +105,7 @@ namespace Toast.Common.Builders
         {
             var serialised = JsonConvert.SerializeObject(paths, Settings.SerializerSsetting);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-            Paths = String.Join("&", deserialised.Select(x => $"/{x.Value}"));
+            Paths = String.Join("/", deserialised.Select(x => x.Value));
             return this;
         }
 
@@ -119,10 +119,11 @@ namespace Toast.Common.Builders
             else if (Endpoint == null) return $"{BaseUrl.TrimEnd('/')}/{Endpoint}";
 
             Endpoint = Endpoint.Replace("{version}", Version);
-            Endpoint = Endpoint.Replace("{appKeys}", AppKey);
+            Endpoint = Endpoint.Replace("{appKey}", AppKey);
 
-            Endpoint = $"{Endpoint.TrimEnd('/')}/{Paths?.TrimStart('/')}?{Queries?.TrimStart('&')}";
-            Endpoint = Endpoint.TrimEnd('?', '/');
+            Endpoint = $"{Endpoint.TrimEnd('/')}/{Paths}";
+            Endpoint = $"{Endpoint.TrimEnd('/')}?{Queries}";
+            Endpoint = Endpoint.TrimEnd('?');
 
             return $"{BaseUrl.TrimEnd('/')}/{Endpoint.TrimStart('/')}";
         }

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -95,29 +95,22 @@ namespace Toast.Common.Builders
         /// <returns>Returns request URL which is string type instance.</returns>
         public string Build()
         {
-            if (this._settings != null && this._endpoint != null)
+            var requestUrl = $"{this._settings.BaseUrl.TrimEnd('/')}/{this._endpoint.TrimStart('/')}";
+
+            requestUrl = requestUrl.Replace("{version}", this._settings.Version);
+            requestUrl = requestUrl.Replace("{appKey}", this._headers.AppKey);
+
+            if (_paths != null)
             {
-                var requestUrl = $"{this._settings.BaseUrl.TrimEnd('/')}/{this._endpoint.TrimStart('/')}";
-
-                requestUrl = requestUrl.Replace("{version}", this._settings.Version);
-                requestUrl = requestUrl.Replace("{appKey}", this._headers.AppKey);
-
-                if (_paths != null)
+                foreach (var key in _paths.Keys)
                 {
-                    foreach (var key in _paths.Keys)
-                    {
-                        requestUrl = requestUrl.Replace($"{{{key}}}", _paths[key]);
-                    }
+                    requestUrl = requestUrl.Replace($"{{{key}}}", _paths[key]);
                 }
-
-                requestUrl = (string.IsNullOrWhiteSpace(this._queries)) ? requestUrl : $"{requestUrl}?{this._queries}";
-
-                return requestUrl;
             }
-            else 
-            {
-                throw new InvalidOperationException();
-            }
+
+            requestUrl = (string.IsNullOrWhiteSpace(this._queries)) ? requestUrl : $"{requestUrl}?{this._queries}";
+
+            return requestUrl;
         }
     }
 }

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -17,43 +17,42 @@ namespace Toast.Common.Builders
         /// <summary>
         /// Gets or sets the Settings for RequestUrlBuilder.
         /// </summary>
-        public ToastSettings Settings { get; private set; }
+        private ToastSettings Settings;
 
         /// <summary>
         /// Gets or sets the BaseUrl for RequestUrlBuilder.
         /// </summary>
-        public string BaseUrl { get; private set; }
+        private string BaseUrl;
 
         /// <summary>
         /// Gets or sets the Version for RequestUrlBuilder.
         /// </summary>
-        public string Version { get; private set; }
+        private string Version;
 
         /// <summary>
         /// Gets or sets the AppKey for RequestUrlBuilder.
         /// </summary>
-        public string AppKey { get; private set; }
+        private string AppKey;
 
         /// <summary>
         /// Gets or sets the Endpoint for RequestUrlBuilder.
         /// </summary>
-        public string Endpoint { get; private set; }
+        private string Endpoint;
 
         /// <summary>
         /// Gets or sets the Quries Dictionay for RequestUrlBuilder.
         /// </summary>
-        public Dictionary<string, string> Queries { get; private set; }
+        private Dictionary<string, string> Queries;
 
         /// <summary>
         /// Gets or sets the Paths Dictionay for RequestUrlBuilder.
         /// </summary
-        public Dictionary<string, string> Paths { get; private set; }
+        private Dictionary<string, string> Paths;
 
         /// <summary>
         /// Gets or sets the RequestUrl for RequestUrlBuilder.
         /// </summary>
-        public string RequestUrl { get; private set; }
-
+        private string RequestUrl;
 
         /// <summary>
         /// Settings the request URL values in setting.
@@ -88,11 +87,11 @@ namespace Toast.Common.Builders
         /// </summary>
         /// <param name="queries"> instance.</param>
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
-        public RequestUrlBuilder WithQueries<T>(T queries)
+        public RequestUrlBuilder WithQueries<T>(T queries) where T : BaseRequestQueries
         {
             try
             {
-                var serialised = JsonConvert.SerializeObject(queries);
+                var serialised = JsonConvert.SerializeObject(queries, Settings.SerializerSsetting);
                 Queries = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
             }
             catch(Exception ex)

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -32,11 +32,8 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithSettings<T>(T settings, string endpoint) where T : ToastSettings
         {
-            if (settings != null)
-            {
-                this._settings = settings;
-                this._endpoint = endpoint;
-            }
+            this._settings = settings;
+            this._endpoint = endpoint;
 
             return this;
         }
@@ -60,13 +57,16 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithQueries<T>(T queries) where T : BaseRequestQueries
         {
-            if (this._settings != null)
+            if (this._settings == null)
             {
-                var serialised = JsonConvert.SerializeObject(queries, this._settings.SerializerSetting);
-                var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-
-                this._queries = string.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
+                throw new InvalidOperationException("_settings is not be null when WithQueries() is invoked");
             }
+
+            var serialised = JsonConvert.SerializeObject(queries, this._settings.SerializerSetting);
+            var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
+
+            this._queries = string.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
+
 
             return this;
         }
@@ -78,13 +78,16 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithPaths<T>(T paths) where T : BaseRequestPaths
         {
-            if (this._settings != null)
+            if (this._settings == null)
             {
-                var serialised = JsonConvert.SerializeObject(paths, this._settings?.SerializerSetting);
-                var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-
-                this._paths = deserialised; 
+                throw new InvalidOperationException("_settings is not be null when WithPaths() is invoked");
             }
+
+            var serialised = JsonConvert.SerializeObject(paths, this._settings?.SerializerSetting);
+            var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
+
+            this._paths = deserialised;
+
 
             return this;
         }
@@ -100,7 +103,7 @@ namespace Toast.Common.Builders
             requestUrl = requestUrl.Replace("{version}", this._settings.Version);
             requestUrl = requestUrl.Replace("{appKey}", this._headers.AppKey);
 
-            if (_paths != null)
+            if (this._paths != null)
             {
                 foreach (var key in _paths.Keys)
                 {
@@ -108,7 +111,10 @@ namespace Toast.Common.Builders
                 }
             }
 
-            requestUrl = (string.IsNullOrWhiteSpace(this._queries)) ? requestUrl : $"{requestUrl}?{this._queries}";
+            if (!string.IsNullOrWhiteSpace(this._queries))
+            {
+                requestUrl += $"?{this._queries}";
+            }
 
             return requestUrl;
         }

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -83,7 +83,7 @@ namespace Toast.Common.Builders
                 throw new InvalidOperationException("_settings is not be null when WithPaths() is invoked");
             }
 
-            var serialised = JsonConvert.SerializeObject(paths, this._settings?.SerializerSetting);
+            var serialised = JsonConvert.SerializeObject(paths, this._settings.SerializerSetting);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
 
             this._paths = deserialised;

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -91,7 +91,8 @@ namespace Toast.Common.Builders
         {
             var serialised = JsonConvert.SerializeObject(queries, Settings.SerializerSsetting);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-            Queries = String.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
+
+            if (deserialised != null) Queries = String.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
 
             return this;
         }
@@ -105,7 +106,9 @@ namespace Toast.Common.Builders
         {
             var serialised = JsonConvert.SerializeObject(paths, Settings.SerializerSsetting);
             var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-            Paths = String.Join("/", deserialised.Select(x => x.Value));
+
+            if (deserialised != null) Paths = String.Join("/", deserialised.Select(x => x.Value));
+            
             return this;
         }
 

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -40,14 +40,14 @@ namespace Toast.Common.Builders
         private string Endpoint;
 
         /// <summary>
-        /// Gets or sets the Quries Dictionay for RequestUrlBuilder.
+        /// Gets or sets the Quries for RequestUrlBuilder.
         /// </summary>
-        private Dictionary<string, string> Queries;
+        private string Queries;
 
         /// <summary>
-        /// Gets or sets the Paths Dictionay for RequestUrlBuilder.
+        /// Gets or sets the Paths for RequestUrlBuilder.
         /// </summary
-        private Dictionary<string, string> Paths;
+        private string Paths;
 
         /// <summary>
         /// Gets or sets the RequestUrl for RequestUrlBuilder.
@@ -89,15 +89,9 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithQueries<T>(T queries) where T : BaseRequestQueries
         {
-            try
-            {
-                var serialised = JsonConvert.SerializeObject(queries, Settings.SerializerSsetting);
-                Queries = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-            }
-            catch(Exception ex)
-            {
-                Queries = null;
-            }
+            var serialised = JsonConvert.SerializeObject(queries, Settings.SerializerSsetting);
+            var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
+            Queries = String.Join("&", deserialised.Select(x => $"{x.Key}={x.Value}"));
 
             return this;
         }
@@ -109,17 +103,9 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithPaths<T>(T paths) where T : BaseRequestPaths
         {
-            try
-            {
-                var serialised = JsonConvert.SerializeObject(paths, Settings.SerializerSsetting);
-                Paths = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
-            }
-            catch(Exception ex)
-            {
-                Paths = null;
-            }
-            
-            
+            var serialised = JsonConvert.SerializeObject(paths, Settings.SerializerSsetting);
+            var deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialised);
+            Paths = String.Join("&", deserialised.Select(x => $"/{x.Value}"));
             return this;
         }
 
@@ -133,11 +119,10 @@ namespace Toast.Common.Builders
             else if (Endpoint == null) return $"{BaseUrl.TrimEnd('/')}/{Endpoint}";
 
             Endpoint = Endpoint.Replace("{version}", Version);
-            Endpoint = Endpoint.Replace("{appKey}", AppKey);
+            Endpoint = Endpoint.Replace("{appKeys}", AppKey);
 
-            Endpoint += String.Join("&", Queries.Select(x => x.Key + "=" + x.Value).ToArray());
-
-            Endpoint += String.Join("&", Paths.Select(x => x.Key + "=" + x.Value).ToArray());
+            Endpoint = $"{Endpoint.TrimEnd('/')}/{Paths?.TrimStart('/')}?{Queries?.TrimStart('&')}";
+            Endpoint = Endpoint.TrimEnd('?', '/');
 
             return $"{BaseUrl.TrimEnd('/')}/{Endpoint.TrimStart('/')}";
         }

--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -50,11 +50,6 @@ namespace Toast.Common.Builders
         private string Paths;
 
         /// <summary>
-        /// Gets or sets the RequestUrl for RequestUrlBuilder.
-        /// </summary>
-        private string RequestUrl;
-
-        /// <summary>
         /// Settings the request URL values in setting.
         /// </summary>
         /// <param name="settings"> instance.</param>

--- a/src/nt-common/Configurations/ToastSettings.cs
+++ b/src/nt-common/Configurations/ToastSettings.cs
@@ -34,7 +34,7 @@ namespace Toast.Common.Configurations
         /// <summary>
         /// sSets the <see cref="JsonSerializerSettings"/> instance.
         /// </summary>
-        public JsonSerializerSettings SerializerSsetting = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, ContractResolver = new CamelCasePropertyNamesContractResolver() };
+        public JsonSerializerSettings SerializerSetting = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, ContractResolver = new CamelCasePropertyNamesContractResolver() };
     }
 
     /// <summary>

--- a/src/nt-common/Configurations/ToastSettings.cs
+++ b/src/nt-common/Configurations/ToastSettings.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Formatting;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -32,12 +34,15 @@ namespace Toast.Common.Configurations
         public virtual SmartFormatter Formatter { get; } = Smart.CreateDefaultSmartFormat(new SmartSettings() { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
 
         /// <summary>
-        /// sSets the <see cref="JsonSerializerSettings"/> instance.
+        /// Gets the <see cref="JsonMediaTypeFormatter"/> instance.
         /// </summary>
-        public JsonSerializerSettings SerializerSetting = new JsonSerializerSettings()
-        { 
-            NullValueHandling = NullValueHandling.Ignore, 
-            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        public JsonMediaTypeFormatter JsonFormatter { get; } = new JsonMediaTypeFormatter()
+        {
+            SerializerSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            }
         };
     }
 

--- a/src/nt-common/Configurations/ToastSettings.cs
+++ b/src/nt-common/Configurations/ToastSettings.cs
@@ -34,7 +34,11 @@ namespace Toast.Common.Configurations
         /// <summary>
         /// sSets the <see cref="JsonSerializerSettings"/> instance.
         /// </summary>
-        public JsonSerializerSettings SerializerSetting = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, ContractResolver = new CamelCasePropertyNamesContractResolver() };
+        public JsonSerializerSettings SerializerSetting = new JsonSerializerSettings()
+        { 
+            NullValueHandling = NullValueHandling.Ignore, 
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
     }
 
     /// <summary>

--- a/src/nt-common/Configurations/ToastSettings.cs
+++ b/src/nt-common/Configurations/ToastSettings.cs
@@ -1,3 +1,6 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
 using SmartFormat;
 using SmartFormat.Core.Settings;
 
@@ -27,6 +30,11 @@ namespace Toast.Common.Configurations
         /// Gets the <see cref="SmartFormatter"/> instance.
         /// </summary>
         public virtual SmartFormatter Formatter { get; } = Smart.CreateDefaultSmartFormat(new SmartSettings() { CaseSensitivity = CaseSensitivityType.CaseInsensitive });
+
+        /// <summary>
+        /// sSets the <see cref="JsonSerializerSettings"/> instance.
+        /// </summary>
+        public JsonSerializerSettings SerializerSsetting = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, ContractResolver = new CamelCasePropertyNamesContractResolver() };
     }
 
     /// <summary>

--- a/src/nt-common/Models/BaseRequestPaths.cs
+++ b/src/nt-common/Models/BaseRequestPaths.cs
@@ -3,16 +3,7 @@ namespace Toast.Common.Models
     /// <summary>
     /// This class is BaseClass for RequestPaths.
     /// </summary>
-    public class BaseRequestPaths
+    public abstract class BaseRequestPaths
     {
-        /// <summary>
-        /// Gets or sets Path1 but only use for test.
-        /// </summary>
-        public string Path1 { get; set; }
-
-        /// <summary>
-        /// Gets or sets Path2 but only use for test.
-        /// </summary>
-        public string Path2 { get; set; }
     }
 }

--- a/src/nt-common/Models/BaseRequestPaths.cs
+++ b/src/nt-common/Models/BaseRequestPaths.cs
@@ -5,5 +5,9 @@ namespace Toast.Common.Models
     /// </summary>
     public class BaseRequestPaths
     {
+        /// <summary>
+        /// Gets or sets Path but only use for test.
+        /// </summary>
+        public string Path { get; set; }
     }
 }

--- a/src/nt-common/Models/BaseRequestPaths.cs
+++ b/src/nt-common/Models/BaseRequestPaths.cs
@@ -1,0 +1,9 @@
+namespace Toast.Common.Models
+{
+    /// <summary>
+    /// This class is BaseClass for RequestPaths.
+    /// </summary>
+    public class BaseRequestPaths
+    {
+    }
+}

--- a/src/nt-common/Models/BaseRequestPaths.cs
+++ b/src/nt-common/Models/BaseRequestPaths.cs
@@ -6,8 +6,13 @@ namespace Toast.Common.Models
     public class BaseRequestPaths
     {
         /// <summary>
-        /// Gets or sets Path but only use for test.
+        /// Gets or sets Path1 but only use for test.
         /// </summary>
-        public string Path { get; set; }
+        public string Path1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets Path2 but only use for test.
+        /// </summary>
+        public string Path2 { get; set; }
     }
 }

--- a/src/nt-common/Models/BaseRequestQueries.cs
+++ b/src/nt-common/Models/BaseRequestQueries.cs
@@ -1,0 +1,6 @@
+namespace Toast.Common.Models
+{
+    public class BaseRequestQueries
+    {
+    }
+}

--- a/src/nt-common/Models/BaseRequestQueries.cs
+++ b/src/nt-common/Models/BaseRequestQueries.cs
@@ -5,5 +5,14 @@ namespace Toast.Common.Models
     /// </summary>
     public class BaseRequestQueries
     {
+        /// <summary>
+        /// Gets or sets Query1 but only use for test.
+        /// </summary>
+        public string Query1 { get; set; }
+
+        /// <summary>
+        /// Gets or sets Query2 but only use for test.
+        /// </summary>
+        public string Query2 { get; set; }
     }
 }

--- a/src/nt-common/Models/BaseRequestQueries.cs
+++ b/src/nt-common/Models/BaseRequestQueries.cs
@@ -1,5 +1,8 @@
 namespace Toast.Common.Models
 {
+    /// <summary>
+    /// This class is BaseClass for RequestQueries.
+    /// </summary>
     public class BaseRequestQueries
     {
     }

--- a/src/nt-common/Models/BaseRequestQueries.cs
+++ b/src/nt-common/Models/BaseRequestQueries.cs
@@ -3,16 +3,7 @@ namespace Toast.Common.Models
     /// <summary>
     /// This class is BaseClass for RequestQueries.
     /// </summary>
-    public class BaseRequestQueries
+    public abstract class BaseRequestQueries
     {
-        /// <summary>
-        /// Gets or sets Query1 but only use for test.
-        /// </summary>
-        public string Query1 { get; set; }
-
-        /// <summary>
-        /// Gets or sets Query2 but only use for test.
-        /// </summary>
-        public string Query2 { get; set; }
     }
 }

--- a/src/nt-common/NhnToast.Common.csproj
+++ b/src/nt-common/NhnToast.Common.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SmartFormat" Version="3.0.0" />
   </ItemGroup>

--- a/src/nt-sms/Models/GetMessageRequestPaths.cs
+++ b/src/nt-sms/Models/GetMessageRequestPaths.cs
@@ -1,0 +1,15 @@
+using Toast.Common.Models;
+
+namespace Toast.Sms.Models
+{
+    /// <summary>
+    /// This represents the model entity for GetMessage request paths.
+    /// </summary>
+    public class GetMessageRequestPaths : BaseRequestPaths
+    {
+        /// <summary>
+        /// Gets or sets the request id.
+        /// </summary>
+        public string RequestId { get; set; }
+    }
+}

--- a/src/nt-sms/Models/GetMessageRequestQueries.cs
+++ b/src/nt-sms/Models/GetMessageRequestQueries.cs
@@ -1,11 +1,13 @@
 using Newtonsoft.Json;
 
+using Toast.Common.Models;
+
 namespace Toast.Sms.Models
 {
     /// <summary>
     /// This represents the entity for GetMessage request query parameters.
     /// </summary>
-    public class GetMessageRequestQueries
+    public class GetMessageRequestQueries : BaseRequestQueries
     {
         /// <summary>
         /// Gets or sets the recipient sequence.

--- a/src/nt-sms/Models/ListMessageStatusRequestQueries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQueries.cs
@@ -7,11 +7,7 @@ namespace Toast.Sms.Models
     /// <summary>
     /// This represents the entity for ListMessageStatus request query parameters.
     /// </summary>
-<<<<<<< HEAD:src/nt-sms/Models/ListMessageStatusRequestQuries.cs
     public class ListMessageStatusRequestQueries : BaseRequestQueries
-=======
-    public class ListMessageStatusRequestQueries
->>>>>>> 032694dea1f196a3e9c6561fa35c011fea1fe4d6:src/nt-sms/Models/ListMessageStatusRequestQueries.cs
     {
         /// <summary>
         /// Gets or sets the start update date.

--- a/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
@@ -7,7 +7,7 @@ namespace Toast.Sms.Models
     /// <summary>
     /// This represents the entity for ListMessageStatus request query parameters.
     /// </summary>
-    public class ListMessageStatusRequestQuries : BaseRequestQueries
+    public class ListMessageStatusRequestQueries : BaseRequestQueries
     {
         /// <summary>
         /// Gets or sets the start update date.

--- a/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
@@ -27,8 +27,7 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page number.
         /// </summary>
-        [JsonProperty("pageNum")]
-        public virtual int? PageNumber { get; set; }
+        public virtual int? PageNum { get; set; }
 
         /// <summary>
         /// Gets or sets the page size.

--- a/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
@@ -27,7 +27,8 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page number.
         /// </summary>
-        public virtual int? PageNum { get; set; }
+        [JsonProperty("pageNum")]
+        public virtual int? PageNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the page size.

--- a/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
@@ -1,28 +1,27 @@
 using Newtonsoft.Json;
 
+using Toast.Common.Models;
+
 namespace Toast.Sms.Models
 {
     /// <summary>
     /// This represents the entity for ListMessageStatus request query parameters.
     /// </summary>
-    public class ListMessageStatusRequestQuries
+    public class ListMessageStatusRequestQuries : BaseRequestQueries
     {
         /// <summary>
         /// Gets or sets the start update date.
         /// </summary>
-        [JsonProperty("startUpdateDate")]
         public virtual string StartUpdateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end update date.
         /// </summary>
-        [JsonProperty("endUpdateDate")]
         public virtual string EndUpdateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the message type.
         /// </summary>
-        [JsonProperty("messageType")]
         public virtual string MessageType { get; set; }
 
         /// <summary>
@@ -34,7 +33,6 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page size.
         /// </summary>
-        [JsonProperty("pageSize")]
         public virtual int? PageSize { get; set; }
     }
 }

--- a/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
+++ b/src/nt-sms/Models/ListMessageStatusRequestQuries.cs
@@ -10,16 +10,19 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the start update date.
         /// </summary>
+        [JsonProperty("startUpdateDate")]
         public virtual string StartUpdateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end update date.
         /// </summary>
+        [JsonProperty("endUpdateDate")]
         public virtual string EndUpdateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the message type.
         /// </summary>
+        [JsonProperty("messageType")]
         public virtual string MessageType { get; set; }
 
         /// <summary>
@@ -31,6 +34,7 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page size.
         /// </summary>
+        [JsonProperty("pageSize")]
         public virtual int? PageSize { get; set; }
     }
 }

--- a/src/nt-sms/Models/ListMessagesRequestQueries.cs
+++ b/src/nt-sms/Models/ListMessagesRequestQueries.cs
@@ -1,52 +1,47 @@
 using Newtonsoft.Json;
 
+using Toast.Common.Models;
+
 namespace Toast.Sms.Models
 {
     /// <summary>
     /// This represents the entity for ListMessages request query parameters.
     /// </summary>
-    public class ListMessagesRequestQueries
+    public class ListMessagesRequestQueries : BaseRequestQueries
     {
         /// <summary>
         /// Gets or sets the request id.
         /// </summary>
-        [JsonProperty("requestId")]
         public virtual string RequestId { get; set; }
 
         /// <summary>
         /// Gets or sets the start request date.
         /// </summary>
-        [JsonProperty("startRequestDate")]
         public virtual string StartRequestDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end request date.
         /// </summary>
-        [JsonProperty("endRequestDate")]
         public virtual string EndRequestDate { get; set; }
 
         /// <summary>
         /// Gets or sets the start create date.
         /// </summary>
-        [JsonProperty("startCreateDate")]
         public virtual string StartCreateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end create date.
         /// </summary>
-        [JsonProperty("endCreateDate")]
         public virtual string EndCreateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the start result date.
         /// </summary>
-        [JsonProperty("startResultDate")]
         public virtual string StartResultDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end result date.
         /// </summary>
-        [JsonProperty("endResultDate")]
         public virtual string EndResultDate { get; set; }
 
         /// <summary>
@@ -64,7 +59,6 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the template id.
         /// </summary>
-        [JsonProperty("templateId")]
         public virtual string TemplateId { get; set; }
 
         /// <summary>
@@ -76,37 +70,31 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the result code.
         /// </summary>
-        [JsonProperty("resultCode")]
         public virtual string ResultCode { get; set; }
 
         /// <summary>
         /// Gets or sets the sub result code.
         /// </summary>
-        [JsonProperty("subResultCode")]
         public virtual string SubResultCode { get; set; }
 
         /// <summary>
         /// Gets or sets the sender grouping key.
         /// </summary>
-        [JsonProperty("senderGroupingKey")]
         public virtual string SenderGroupingKey { get; set; }
 
         /// <summary>
         /// Gets or sets the recipient grouping key.
         /// </summary>
-        [JsonProperty("recipientGroupingKey")]
         public virtual string RecipientGroupingKey { get; set; }
 
         /// <summary>
         /// Gets or sets the page number.
         /// </summary>
-        [JsonProperty("pageNum")]
-        public virtual int? PageNumber { get; set; }
+        public virtual int? PageNum { get; set; }
 
         /// <summary>
         /// Gets or sets the page size.
         /// </summary>
-        [JsonProperty("pageSize")]
         public virtual int? PageSize { get; set; }
     }
 }

--- a/src/nt-sms/Models/ListMessagesRequestQueries.cs
+++ b/src/nt-sms/Models/ListMessagesRequestQueries.cs
@@ -10,36 +10,43 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the request id.
         /// </summary>
+        [JsonProperty("requestId")]
         public virtual string RequestId { get; set; }
 
         /// <summary>
         /// Gets or sets the start request date.
         /// </summary>
+        [JsonProperty("startRequestDate")]
         public virtual string StartRequestDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end request date.
         /// </summary>
+        [JsonProperty("endRequestDate")]
         public virtual string EndRequestDate { get; set; }
 
         /// <summary>
         /// Gets or sets the start create date.
         /// </summary>
+        [JsonProperty("startCreateDate")]
         public virtual string StartCreateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end create date.
         /// </summary>
+        [JsonProperty("endCreateDate")]
         public virtual string EndCreateDate { get; set; }
 
         /// <summary>
         /// Gets or sets the start result date.
         /// </summary>
+        [JsonProperty("startResultDate")]
         public virtual string StartResultDate { get; set; }
 
         /// <summary>
         /// Gets or sets the end result date.
         /// </summary>
+        [JsonProperty("endResultDate")]
         public virtual string EndResultDate { get; set; }
 
         /// <summary>
@@ -57,6 +64,7 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the template id.
         /// </summary>
+        [JsonProperty("templateId")]
         public virtual string TemplateId { get; set; }
 
         /// <summary>
@@ -68,21 +76,25 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the result code.
         /// </summary>
+        [JsonProperty("resultCode")]
         public virtual string ResultCode { get; set; }
 
         /// <summary>
         /// Gets or sets the sub result code.
         /// </summary>
+        [JsonProperty("subResultCode")]
         public virtual string SubResultCode { get; set; }
 
         /// <summary>
         /// Gets or sets the sender grouping key.
         /// </summary>
+        [JsonProperty("senderGroupingKey")]
         public virtual string SenderGroupingKey { get; set; }
 
         /// <summary>
         /// Gets or sets the recipient grouping key.
         /// </summary>
+        [JsonProperty("recipientGroupingKey")]
         public virtual string RecipientGroupingKey { get; set; }
 
         /// <summary>
@@ -94,6 +106,7 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page size.
         /// </summary>
+        [JsonProperty("pageSize")]
         public virtual int? PageSize { get; set; }
     }
 }

--- a/src/nt-sms/Models/ListMessagesRequestQueries.cs
+++ b/src/nt-sms/Models/ListMessagesRequestQueries.cs
@@ -90,7 +90,8 @@ namespace Toast.Sms.Models
         /// <summary>
         /// Gets or sets the page number.
         /// </summary>
-        public virtual int? PageNum { get; set; }
+        [JsonProperty("pageNum")]
+        public virtual int? PageNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the page size.

--- a/src/nt-sms/Triggers/GetMessage.cs
+++ b/src/nt-sms/Triggers/GetMessage.cs
@@ -81,8 +81,9 @@ namespace Toast.Sms.Triggers
             var paths = new GetMessageRequestPaths() { RequestId = requestId };
 
             var requestUrl = new RequestUrlBuilder()
-                .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)
-                .WithHeaders(headers).WithQueries(queries)
+                .WithSettings(this._settings, this._settings.Endpoints.GetMessage)
+                .WithHeaders(headers)
+                .WithQueries(queries)
                 .WithPaths(paths).Build();
 
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);

--- a/src/nt-sms/Triggers/GetMessage.cs
+++ b/src/nt-sms/Triggers/GetMessage.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Common.Validators;
@@ -61,17 +62,19 @@ namespace Toast.Sms.Triggers
                 return new BadRequestResult();
             }
 
-            var baseUrl = this._settings.BaseUrl;
-            var version = this._settings.Version;
-            var endpoint = this._settings.Endpoints.GetMessage;
-            var options = new GetMessageRequestUrlOptions()
+            GetMessageRequestQueries queries = new GetMessageRequestQueries()
             {
-                Version = version,
-                AppKey = headers.AppKey,
-                RequestId = requestId,
-                RecipientSeq = int.TryParse(req.Query["recipientSeq"].ToString(), out int recipientSeqVal) ? recipientSeqVal : 0,
+                RecipientSequenceNumber = int.TryParse(req.Query["recipientSeq"].ToString(), out int recipientSeqVal) ? recipientSeqVal : 0
             };
-            var requestUrl = this._settings.Formatter.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+            
+            string[] paths = new string[] {"requestId", requestId };
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)
+                .WithHeaders(headers).WithQueries(queries)
+                .WithPaths(paths).Build();
+            
+            var quries = new GetMessageRequestQueries();
 
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.GetAsync(requestUrl).ConfigureAwait(false);

--- a/src/nt-sms/Triggers/GetMessage.cs
+++ b/src/nt-sms/Triggers/GetMessage.cs
@@ -66,8 +66,8 @@ namespace Toast.Sms.Triggers
             {
                 RecipientSequenceNumber = int.TryParse(req.Query["recipientSeq"].ToString(), out int recipientSeqVal) ? recipientSeqVal : 0
             };
-            
-            string[] paths = new string[] {"requestId", requestId };
+
+            var paths = new GetMessageRequestPaths() { RequestId = requestId };
 
             var requestUrl = new RequestUrlBuilder()
                 .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)

--- a/src/nt-sms/Triggers/ListMessageStatus.cs
+++ b/src/nt-sms/Triggers/ListMessageStatus.cs
@@ -15,12 +15,12 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
-
 
 namespace Toast.Sms.Triggers
 {
@@ -62,21 +62,21 @@ namespace Toast.Sms.Triggers
             {
                 return new BadRequestResult();
             }
-
-            var baseUrl = this._settings.BaseUrl;
-            var version = this._settings.Version;
-            var endpoint = this._settings.Endpoints.GetMessage;
-            var options = new ListMessageStatusRequestUrlOptions()
+            
+            var queries = new ListMessageStatusRequestQuries()
             {
-                Version = version,
-                AppKey = headers.AppKey,
                 StartUpdateDate = req.Query["startUpdateDate"].ToString(),
                 EndUpdateDate = req.Query["endUpdateDate"].ToString(),
                 MessageType = req.Query["messageType"].ToString(),
-                PageNum = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumVal) ? pageNumVal : 1,
+                PageNumber = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumVal) ? pageNumVal : 1,
                 PageSize = int.TryParse(req.Query["pageSize"].ToString(), out int pageSizeVal) ? pageSizeVal : 15,
             };
-            var requestUrl = this._settings.Formatter.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(this._settings, this._settings.Endpoints.ListMessageStatus)
+                .WithHeaders(headers)
+                .WithQueries(queries)
+                .Build();
 
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.GetAsync(requestUrl).ConfigureAwait(false);

--- a/src/nt-sms/Triggers/ListMessageStatus.cs
+++ b/src/nt-sms/Triggers/ListMessageStatus.cs
@@ -30,11 +30,11 @@ namespace Toast.Sms.Triggers
     public class ListMessageStatus
     {
         private readonly ToastSettings<SmsEndpointSettings> _settings;
-        private readonly IValidator<ListMessageStatusRequestQuries> _validator;
+        private readonly IValidator<ListMessageStatusRequestQueries> _validator;
         private readonly HttpClient _http;
         private readonly ILogger<ListMessageStatus> _logger;
 
-        public ListMessageStatus(ToastSettings<SmsEndpointSettings> settings, IValidator<ListMessageStatusRequestQuries> validator, IHttpClientFactory factory, ILogger<ListMessageStatus> log)
+        public ListMessageStatus(ToastSettings<SmsEndpointSettings> settings, IValidator<ListMessageStatusRequestQueries> validator, IHttpClientFactory factory, ILogger<ListMessageStatus> log)
         {
             this._settings = settings.ThrowIfNullOrDefault();
             this._validator = validator.ThrowIfNullOrDefault();
@@ -70,10 +70,10 @@ namespace Toast.Sms.Triggers
                 return new BadRequestResult();
             }
 
-            var queries = default(ListMessageStatusRequestQuries);
+            var queries = default(ListMessageStatusRequestQueries);
             try
             {
-                queries = await req.To<ListMessageStatusRequestQuries>(SourceFrom.Query).Validate(this._validator).ConfigureAwait(false);
+                queries = await req.To<ListMessageStatusRequestQueries>(SourceFrom.Query).Validate(this._validator).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms/Triggers/ListMessageStatus.cs
+++ b/src/nt-sms/Triggers/ListMessageStatus.cs
@@ -68,7 +68,7 @@ namespace Toast.Sms.Triggers
                 StartUpdateDate = req.Query["startUpdateDate"].ToString(),
                 EndUpdateDate = req.Query["endUpdateDate"].ToString(),
                 MessageType = req.Query["messageType"].ToString(),
-                PageNumber = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumVal) ? pageNumVal : 1,
+                PageNum = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumVal) ? pageNumVal : 1,
                 PageSize = int.TryParse(req.Query["pageSize"].ToString(), out int pageSizeVal) ? pageSizeVal : 15,
             };
 

--- a/src/nt-sms/Triggers/ListMessages.cs
+++ b/src/nt-sms/Triggers/ListMessages.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Common.Validators;
@@ -74,13 +75,8 @@ namespace Toast.Sms.Triggers
                 return new BadRequestResult();
             }
 
-            var baseUrl = this._settings.BaseUrl;
-            var version = this._settings.Version;
-            var endpoint = this._settings.Endpoints.ListMessages;
-            var options = new ListMessagesRequestUrlOptions()
+            ListMessagesRequestQueries queries = new ListMessagesRequestQueries()
             {
-                Version = version,
-                AppKey = headers.AppKey,
                 RequestId = req.Query["requestId"].ToString(),
                 StartRequestDate = req.Query["startRequestDate"].ToString(),
                 EndRequestDate = req.Query["endRequestDate"].ToString(),
@@ -88,18 +84,23 @@ namespace Toast.Sms.Triggers
                 EndCreateDate = req.Query["endCreateDate"].ToString(),
                 StartResultDate = req.Query["startResultDate"].ToString(),
                 EndResultDate = req.Query["endResultDate"].ToString(),
-                SendNo = req.Query["sendNo"].ToString(),
-                RecipientNo = req.Query["recipientNo"].ToString(),
+                SendNumber = req.Query["sendNo"].ToString(),
+                RecipientNumber = req.Query["recipientNo"].ToString(),
                 TemplateId = req.Query["templateId"].ToString(),
-                MsgStatus = req.Query["msgStatus"].ToString(),
+                MessageStatus = req.Query["msgStatus"].ToString(),
                 ResultCode = req.Query["resultCode"].ToString(),
                 SubResultCode = req.Query["subResultCode"].ToString(),
                 SenderGroupingKey = req.Query["senderGroupingKey"].ToString(),
                 RecipientGroupingKey = req.Query["recipientGroupingKey"].ToString(),
-                PageNum = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumParse) ? pageNumParse : 1,
-                PageSize = int.TryParse(req.Query["pageSize"].ToString(), out int pageSizeParse) ? pageSizeParse : 15         
+                PageNumber = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumParse) ? pageNumParse : 1,
+                PageSize = int.TryParse(req.Query["pageSize"].ToString(), out int pageSizeParse) ? pageSizeParse : 15
             };
-            var requestUrl = this._settings.Formatter.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(this._settings, this._settings.Endpoints.ListMessageStatus)
+                .WithHeaders(headers).WithQueries(queries)
+                .Build();
 
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.GetAsync(requestUrl).ConfigureAwait(false);

--- a/src/nt-sms/Triggers/ListMessages.cs
+++ b/src/nt-sms/Triggers/ListMessages.cs
@@ -93,7 +93,7 @@ namespace Toast.Sms.Triggers
             }
 
             var requestUrl = new RequestUrlBuilder()
-                .WithSettings(this._settings, this._settings.Endpoints.ListMessageStatus)
+                .WithSettings(this._settings, this._settings.Endpoints.ListMessages)
                 .WithHeaders(headers).WithQueries(queries)
                 .Build();
 

--- a/src/nt-sms/Triggers/ListMessages.cs
+++ b/src/nt-sms/Triggers/ListMessages.cs
@@ -92,7 +92,7 @@ namespace Toast.Sms.Triggers
                 SubResultCode = req.Query["subResultCode"].ToString(),
                 SenderGroupingKey = req.Query["senderGroupingKey"].ToString(),
                 RecipientGroupingKey = req.Query["recipientGroupingKey"].ToString(),
-                PageNumber = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumParse) ? pageNumParse : 1,
+                PageNum = int.TryParse(req.Query["pageNum"].ToString(), out int pageNumParse) ? pageNumParse : 1,
                 PageSize = int.TryParse(req.Query["pageSize"].ToString(), out int pageSizeParse) ? pageSizeParse : 15
             };
 

--- a/src/nt-sms/Triggers/SendMessages.cs
+++ b/src/nt-sms/Triggers/SendMessages.cs
@@ -82,7 +82,7 @@ namespace Toast.Sms.Triggers
                 .WithHeaders(headers)
                 .Build();
 
-            var content = new ObjectContent<SendMessagesRequestBody>(payload, new JsonMediaTypeFormatter(), "application/json");
+            var content = new ObjectContent<SendMessagesRequestBody>(payload, this._settings.JsonFormatter, "application/json");
 
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.PostAsync(requestUrl, content).ConfigureAwait(false);

--- a/src/nt-sms/Triggers/SendMessages.cs
+++ b/src/nt-sms/Triggers/SendMessages.cs
@@ -70,21 +70,14 @@ namespace Toast.Sms.Triggers
                 return new BadRequestResult();
             }
 
-            var payloads = default(SendMessagesRequestBody);
+            var payload = default(SendMessagesRequestBody);
             try
             {
-                payloads = await req.To<SendMessagesRequestBody>(SourceFrom.Body).Validate(this._validator).ConfigureAwait(false);
+                payload = await req.To<SendMessagesRequestBody>(SourceFrom.Body).Validate(this._validator).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 return new BadRequestResult();
-            }
-
-            var data = default(object);
-            using (var reader = new StreamReader(req.Body))
-            {
-                var json = await reader.ReadToEndAsync().ConfigureAwait(false);
-                data = JsonConvert.DeserializeObject<object>(json);
             }
 
             var requestUrl = new RequestUrlBuilder()
@@ -92,15 +85,15 @@ namespace Toast.Sms.Triggers
                 .WithHeaders(headers)
                 .Build();
 
-            var content = new ObjectContent<object>(data, new JsonMediaTypeFormatter(), "application/json");
+            var content = new ObjectContent<object>(payload, new JsonMediaTypeFormatter(), "application/json");
 
             // Act
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.PostAsync(requestUrl, content).ConfigureAwait(false);
 
-            var payload = await result.Content.ReadAsAsync<object>().ConfigureAwait(false);
+            var resultPayload = await result.Content.ReadAsAsync<object>().ConfigureAwait(false);
 
-            return new OkObjectResult(payload);
+            return new OkObjectResult(resultPayload);
         }
     }
 }

--- a/src/nt-sms/Triggers/SendMessages.cs
+++ b/src/nt-sms/Triggers/SendMessages.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
@@ -18,8 +17,6 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-
-using Newtonsoft.Json;
 
 using Toast.Common.Builders;
 using Toast.Common.Configurations;
@@ -85,13 +82,12 @@ namespace Toast.Sms.Triggers
                 .WithHeaders(headers)
                 .Build();
 
-            var content = new ObjectContent<object>(payload, new JsonMediaTypeFormatter(), "application/json");
+            var content = new ObjectContent<SendMessagesRequestBody>(payload, new JsonMediaTypeFormatter(), "application/json");
 
-            // Act
             this._http.DefaultRequestHeaders.Add("X-Secret-Key", headers.SecretKey);
             var result = await this._http.PostAsync(requestUrl, content).ConfigureAwait(false);
 
-            var resultPayload = await result.Content.ReadAsAsync<object>().ConfigureAwait(false);
+            var resultPayload = await result.Content.ReadAsAsync<SendMessagesResponse>().ConfigureAwait(false);
 
             return new OkObjectResult(resultPayload);
         }

--- a/src/nt-sms/Triggers/SendMessages.cs
+++ b/src/nt-sms/Triggers/SendMessages.cs
@@ -19,6 +19,7 @@ using Microsoft.OpenApi.Models;
 
 using Newtonsoft.Json;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Common.Validators;
@@ -61,15 +62,6 @@ namespace Toast.Sms.Triggers
                 return new BadRequestResult();
             }
 
-            var baseUrl = this._settings.BaseUrl;
-            var version = this._settings.Version;
-            var endpoint = this._settings.Endpoints.SendMessages;
-            var options = new RequestUrlOptions()
-            {
-                Version = version,
-                AppKey = headers.AppKey
-            };
-
             var data = default(object);
             using (var reader = new StreamReader(req.Body))
             {
@@ -77,7 +69,10 @@ namespace Toast.Sms.Triggers
                 data = JsonConvert.DeserializeObject<object>(json);
             }
 
-            var requestUrl = this._settings.Formatter.Format($"{baseUrl.TrimEnd('/')}/{endpoint.TrimStart('/')}", options);
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(this._settings, this._settings.Endpoints.SendMessages)
+                .WithHeaders(headers)
+                .Build();
 
             var content = new ObjectContent<object>(data, new JsonMediaTypeFormatter(), "application/json");
 

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -20,7 +20,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         /// <param name="headers"><see cref="ListMessageStatusRequestQuries"/> instance.</param>
         /// <returns>Returns the <see cref="ListMessageStatusRequestQuries"/> instance.</returns>
-        public static async Task<ListMessageStatusRequestQuries> Validate(this Task<ListMessageStatusRequestQuries> queries, IValidator<ListMessageStatusRequestQuries> validator)
+        public static async Task<ListMessageStatusRequestQueries> Validate(this Task<ListMessageStatusRequestQueries> queries, IValidator<ListMessageStatusRequestQueries> validator)
         {
             var instance = await queries.ConfigureAwait(false);
 
@@ -40,7 +40,7 @@ namespace Toast.Sms.Validators
     /// <summary>
     /// This represents the validator entity for the ListMessageStatus request query parameters.
     /// </summary>
-    public class ListMessageStatusRequestQueryValidator : AbstractValidator<ListMessageStatusRequestQuries>
+    public class ListMessageStatusRequestQueryValidator : AbstractValidator<ListMessageStatusRequestQueries>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessageStatusRequestQueryValidator"/> class.

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 using FluentAssertions;
 
+using Newtonsoft.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Toast.Common.Builders;
@@ -89,16 +89,16 @@ namespace Toast.Common.Tests.Builders
         }
 
         [TestMethod]
-        public void Given_Default_Queries_Instance_When_WithQueries_Invoked_Then_It_Should_Return_Result()
+        public void Given_Fake_Queries_Instance_When_WithQueries_Invoked_Then_It_Should_Return_Result()
         {
             var settings = new ToastSettings() { };
             string endpoint = "";
-            var queries = new FakeRequestQuries();
+            var queries = new FakeRequestQuries() {FakeQueries = "Fakequeries"};
             var result = new RequestUrlBuilder().WithSettings(settings, endpoint).WithQueries(queries);
             var resultQueries = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
             
-            result.Should().BeOfType<RequestUrlBuilder>();
-            resultQueries.Should().Be("");
+            result.Should().BeOfType(typeof(RequestUrlBuilder));
+            resultQueries.Should().Be("fakeQueries=Fakequeries");
         }
 
         [TestMethod]
@@ -106,22 +106,22 @@ namespace Toast.Common.Tests.Builders
         {
             var settings = new ToastSettings() { };
             string endpoint = "";
-            var paths = new FakeRequestPaths();
+            var paths = new FakeRequestPaths() {FakePaths="Fakepaths"};
             var result = new RequestUrlBuilder().WithSettings(settings,endpoint).WithPaths(paths);
             var resultPaths = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-
-            result.Should().BeOfType<RequestUrlBuilder>();
-            resultPaths.Should().BeEquivalentTo(new Dictionary<string, string>());
+            
+            result.Should().BeOfType(typeof(RequestUrlBuilder));
+            resultPaths.Should().BeOfType(typeof(Dictionary<string, string>));
         }
 
         [DataTestMethod]
-        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms")]
-        public void Given_Default_RequestUrlBuilder_Instance_When_Build_Invoked_Then_It_Should_Return_Result(string baseUrl, string endpoint, string version, string appKey, string expected)
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms/{fakePaths}", "v3.0", "appKey", "FakePaths","FakeQueries" ,"https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/FakePaths?fakeQueries=FakeQueries")]
+        public void Given_Default_RequestUrlBuilder_Instance_When_Build_Invoked_Then_It_Should_Return_Result(string baseUrl, string endpoint, string version, string appKey, string path,string query,string expected)
         {
             var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
             var headers = new RequestHeaderModel() { AppKey = appKey};
-            var queries = new FakeRequestQuries();
-            var paths = new FakeRequestPaths();
+            var queries = new FakeRequestQuries() { FakeQueries = query};
+            var paths = new FakeRequestPaths() { FakePaths = path};
 
             var result = new RequestUrlBuilder()
                 .WithSettings(settings, endpoint)

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -60,19 +60,27 @@ namespace Toast.Common.Tests.Builders
         [TestMethod]
         public void Given_Default_Queries_Instance_When_WithQueries_Invoked_Then_It_Should_Return_Result()
         {
+            var settings = new ToastSettings() { };
+            string endpoint = "";
             var queries = new FakeRequestQuries();
-            var result = new RequestUrlBuilder().WithQueries(queries); 
+            var result = new RequestUrlBuilder().WithSettings(settings, endpoint).WithQueries(queries);
+            var resultQueries = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
             result.Should().BeOfType<RequestUrlBuilder>();
+            resultQueries.Should().Be("");
         }
 
         [TestMethod]
         public void Given_Default_Paths_Instance_When_WithPaths_Invoked_Then_It_Should_Return_Result()
         {
+            var settings = new ToastSettings() { };
+            string endpoint = "";
             var paths = new FakeRequestPaths();
-            var result = new RequestUrlBuilder().WithPaths(paths);
+            var result = new RequestUrlBuilder().WithSettings(settings,endpoint).WithPaths(paths);
+            var resultPaths = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
             result.Should().BeOfType<RequestUrlBuilder>();
+            resultPaths.Should().BeEquivalentTo(new Dictionary<string, string>());
         }
 
         [DataTestMethod]

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -21,83 +21,89 @@ namespace Toast.Common.Tests.Builders
     public class RequestBuilderValidatorTests
     {
         [DataTestMethod]
+        [DataRow("BaseUrl", "Version", "Endpoint")]
         [DataRow(null, null, null)]
         [DataRow(null, "Version", "Endpoint")]
         [DataRow("BaseUrl", null, "Endpoint")]
         [DataRow("BaseUrl", "Version", null)]
-        [DataRow("BaseUrl", "Version", "Endpoint")]
         public void Given_Parameters_When_WithSettins_Invoked_Then_It_Should_Return_Result(string baseUrl, string version, string endpoint)
         {
             var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
             var result = new RequestUrlBuilder().WithSettings(settings, endpoint);
 
             var builder = typeof(RequestUrlBuilder);
-            var resultBaseUrl = builder.GetField("BaseUrl", BindingFlags.Public)?.GetValue(result);
-            var resultVersion = builder.GetField("Version", BindingFlags.Public)?.GetValue(result);
-
+            
+            var resultBaseUrl = typeof(RequestUrlBuilder).GetField("BaseUrl", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
+            var resultVersion = typeof(RequestUrlBuilder).GetField("Version", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
+            
             resultBaseUrl.Should().Be(baseUrl);
             resultVersion.Should().Be(version);
         }
 
         [DataTestMethod]
-        [DataRow(null)]
         [DataRow("AppKey")]
+        [DataRow(null)]
         public void Given_Parameters_When_WithHeaders_Invoked_Then_It_Should_Return_Result(string appKey)
         {
             var headers = new RequestHeaderModel() { AppKey = appKey };
             var result = new RequestUrlBuilder().WithHeaders(headers);
-            var resultAppKey = typeof(RequestUrlBuilder).GetField("AppKey", BindingFlags.Public)?.GetValue(result);
+
+            var resultAppKey = typeof(RequestUrlBuilder).GetField("AppKey", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
             resultAppKey.Should().Be(appKey);
         }
 
         [DataTestMethod]
-        [DataRow(null, null)]
-        [DataRow("Key1", "Value1")]
-        public void Given_Parameters_When_WithQueries_Invoked_Then_It_Should_Return_Result(string key, string value)
+        [DataRow("This is Query1", "This is Query2", "query1=This is Query1&query2=This is Query2")]
+        [DataRow(null, null, "")]
+        [DataRow(null, "This is Query2", "query2=This is Query2")]
+        public void Given_Parameters_When_WithQueries_Invoked_Then_It_Should_Return_Result(string value1, string value2, string expected)
         {
-            var queries = new BaseRequestQueries() { Name = key, Value = value };
-            var result = new RequestUrlBuilder().WithQueries(queries);
+            var settings = new ToastSettings();
+            var queries = new BaseRequestQueries() { Query1 = value1, Query2 = value2 };
+            var result = new RequestUrlBuilder().WithSettings(settings, "").WithQueries(queries);
+
+            var resultQuery = typeof(RequestUrlBuilder).GetField("Queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
             
-            var query = typeof(RequestUrlBuilder).GetField("Queries", BindingFlags.Public);
-            var resultQuery = query?.GetValue(result) as Dictionary<string, string>;
-
-            resultQuery?.Keys.Should().Contain(key);
-            resultQuery?.Values.Should().Contain(value);
+            resultQuery.Should().Be(expected);
+            //var query = typeof(RequestUrlBuilder).GetField("Queries", BindingFlags.Public);
+            //var resultQuery = query?.GetValue(result) as Dictionary<string, string>;
         }
 
         [DataTestMethod]
-        [DataRow(null, null)]
-        [DataRow("Key1", "Value1")]
-        public void Given_Parameters_When_WithPaths_Invoked_Then_It_Should_Return_Result(string key, string value)
+        [DataRow("This is Path1", "This is Path2", "This is Path1/This is Path2")]
+        [DataRow(null, null, "")]
+        [DataRow(null, "This is Path2", "This is Path2")]
+        public void Given_Parameters_When_WithPaths_Invoked_Then_It_Should_Return_Result(string value1, string value2, string expected)
         {
-            var paths = new BaseRequestPaths() { Name = key, Value = value };
-            var result = new RequestUrlBuilder().WithPaths(paths);
+            var settings = new ToastSettings();
+            var paths = new BaseRequestPaths() { Path1 = value1, Path2 = value2 };
+            var result = new RequestUrlBuilder().WithSettings(settings, "").WithPaths(paths);
 
-            var path = typeof(RequestUrlBuilder).GetField("Queries", BindingFlags.Public);
-            var resultPath = path?.GetValue(result) as Dictionary<string, string>;
+            var resultPath = typeof(RequestUrlBuilder).GetField("Paths", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
-            resultPath?.Keys.Should().Contain(key);
-            resultPath?.Values.Should().Contain(value);
+            resultPath.Should().Be(expected);
+            //var path = typeof(RequestUrlBuilder).GetField("Queries", BindingFlags.Public);
+            //var resultPath = path?.GetValue(result) as Dictionary<string, string>;
         }
 
         [DataTestMethod]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", "Query1", "query2", "Query2", "path", "Path", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/AppKey/sender/sms/Path?query1=Query1&query2=Query2")]
-        [DataRow(null, "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query", "Query", "path", "Path", "/sms/{version}/appKeys/{appKey}/sender/sms/Path?query1=Query1&query2=Query2")]
-        [DataRow("https://api-sms.cloud.toast.com/", null, "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", "Query1", "query2", "Query2", "path", "Path", "https://api-sms.cloud.toast.com/sms/appKeys/AppKey/sender/sms/Path??query1=Query1&query2=Query2")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", null, "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", "Query1", "query2", "Query2", "path", "Path", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys//sender/sms/Path?query1=Query1&query2=Query2")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", null, "query1", "Query1", "query2", "Query2", "path", "Path", "https://api-sms.cloud.toast.com/")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", null, "query2", "Query2", "path", "Path", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/AppKey/sender/sms/Path?query2=Query2")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", "Query1", "query2", null, "path", "Path", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/AppKey/sender/sms/Path?query1=Query1")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", "Query1", "query2", "Query2", "path", null, "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/AppKey/sender/sms?query1=Query1&query2=Query2")]
-        [DataRow("https://api-sms.cloud.toast.com/", "v3.0", "AppKey", "/sms/{version}/appKeys/{appKey}/sender/sms", "query1", null, null, null, null, null, "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/AppKey/sender/sms")]
-
-        public void Given_Parameters_When_Builder_Invoked_Then_It_Should_Return_Result(string baseUrl, string version, string appKey, string endpoint, string queryKey1, string queryValue1, string queryKey2, string queryValue2, string pahtKey, string pathValue, string expected)
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "path1", "path2", "query1", "query2", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/path1/path2?query1=query1&query2=query2")]
+        [DataRow(null, "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "path1", "path2", "query1", "query2", "/sms/{version}/appKeys/{appKey}/sender/sms")]
+        [DataRow("https://api-sms.cloud.toast.com/", null, "v3.0", "appKey", "path1", "path2", "query1", "query2", "https://api-sms.cloud.toast.com/")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", null, "appKey", "path1", "path2", "query1", "query2", "https://api-sms.cloud.toast.com/sms//appKeys/appKey/sender/sms/path1/path2?query1=query1&query2=query2")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", null, "path1", "path2", "query1", "query2", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys//sender/sms/path1/path2?query1=query1&query2=query2")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", null, "path2", "query1", "query2", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/path2?query1=query1&query2=query2")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "path1", null, "query1", "query2", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/path1?query1=query1&query2=query2")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "path1", "path2", null, "query2", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/path1/path2?query2=query2")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "path1", "path2", "query1", null, "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms/path1/path2?query1=query1")]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", null, null, null, null, "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms")]
+        public void Given_Parameters_When_Builder_Invoked_Then_It_Should_Return_Result(string baseUrl, string endpoint, string version, string appKey, string pathValue1, string pathValue2, string queryValue1, string queryValue2, string expected)
         {
             var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
             var headers = new RequestHeaderModel() { AppKey = appKey };
-            var queries = new BaseRequestQueries() { Name1 = queryKey1, Name2 = queryKey2, Value1 = queryValue1, Value2 = queryValue2 };
-            var paths = new BaseRequestPaths() { Name = pahtKey, Value = pathValue };
+            var queries = new BaseRequestQueries() { Query1 = queryValue1, Query2 = queryValue2 };
+            var paths = new BaseRequestPaths() { Path1 = pathValue1, Path2 = pathValue2 };
 
             var requestUrl = new RequestUrlBuilder()
              .WithSettings(settings, endpoint)

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -20,15 +20,15 @@ namespace Toast.Common.Tests.Builders
         [TestMethod]
         public void Given_RequestUrlBuilder_Type_Then_It_Should_Contain_Fields()
         {
-            var SettingsFi = typeof(RequestUrlBuilder).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);
-            var EndpointFi = typeof(RequestUrlBuilder).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance);
-            var QueriesFi = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance);
-            var PathsFi = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance);
+            var settingsFi = typeof(RequestUrlBuilder).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);
+            var endpointFi = typeof(RequestUrlBuilder).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance);
+            var queriesFi = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance);
+            var pathsFi = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            SettingsFi?.FieldType.Name.Should().Be("ToastSettings");
-            EndpointFi?.FieldType.Name.Should().Be("String");
-            QueriesFi?.FieldType.Name.Should().Be("String");
-            PathsFi?.FieldType.Name.Should().Be("Dictionary`2");
+            settingsFi?.FieldType.Name.Should().Be("ToastSettings");
+            endpointFi?.FieldType.Name.Should().Be("String");
+            queriesFi?.FieldType.Name.Should().Be("String");
+            pathsFi?.FieldType.Name.Should().Be("Dictionary`2");
         }
 
         [TestMethod]
@@ -61,8 +61,8 @@ namespace Toast.Common.Tests.Builders
         public void Given_Default_Queries_Instance_When_WithQueries_Invoked_Then_It_Should_Return_Result()
         {
             var queries = new FakeRequestQuries();
-            var result = new RequestUrlBuilder().WithQueries(queries);
-            
+            var result = new RequestUrlBuilder().WithQueries(queries); 
+
             result.Should().BeOfType<RequestUrlBuilder>();
         }
 

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Toast.Common.Builders;
+using Toast.Common.Configurations;
+using Toast.Common.Exceptions;
+using Toast.Common.Models;
+using Toast.Common.Validators;
+
+
+namespace Toast.Common.Tests.Builders
+{
+    [TestClass]
+    public class RequestBuilderValidatorTests
+    {
+        [DataTestMethod]
+        [DataRow(null, null, null)]
+        [DataRow(null, "Version", "Endpoint")]
+        [DataRow("BaseUrl", null, "Endpoint")]
+        [DataRow("BaseUrl", "Version", null)]
+        [DataRow("BaseUrl", "Version", "Endpoint")]
+        public void Given_Parameters_When_WithSettins_Invoked_Then_It_Should_Return_Result(string baseUrl, string version, string endpoint)
+        {
+            var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
+
+            var result = new RequestUrlBuilder().WithSettings(settings, endpoint);
+
+            result.BaseUrl.Should().Be(baseUrl);
+            result.Version.Should().Be(version);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("AppKey")]
+        public void Given_Parameters_When_WithHeaders_Invoked_Then_It_Should_Return_Result(string appKey)
+        {
+            var headers = new RequestHeaderModel() { AppKey = appKey };
+
+            var result = new RequestUrlBuilder().WithHeaders(headers);
+
+            result.AppKey.Should().Be(appKey);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null, "Value cannot be null. (Parameter 'name')")]
+        [DataRow("Key1", "Value1", null)]
+        public void Given_Parameters_When_WithQueries_Invoked_Then_It_Should_Return_Result(string key, string value, string expected)
+        {
+            string? exceptionMessage = null;
+
+            try
+            {
+                var queries = new JObject();
+                queries.Add(key, value);
+
+                var result = new RequestUrlBuilder().WithQueries(queries);
+
+                result.Queries.Keys.Should().Contain(key);
+                result.Queries.Values.Should().Contain(value);
+            }
+            catch (Exception ex)
+            {
+                exceptionMessage = ex.Message;
+            }
+
+            exceptionMessage.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null, "Object reference not set to an instance of an object.")]
+        [DataRow("Key", "Value", null)]
+        public void Given_Parameters_When_WithPaths_Invoked_Then_It_Should_Return_Result(string key, string value, string expected)
+        {
+            string? exceptionMessage = null;
+
+            try
+            {
+                var paths = new string[] { key, value };
+
+                var result = new RequestUrlBuilder().WithPaths(paths);
+
+                for (int i = 0; i < paths.Length; i += 2)
+                {
+                    result.Paths.Keys.Should().Contain(paths[i]);
+                    result.Paths.Values.Should().Contain(paths[i + 1]);
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptionMessage = ex.Message;
+            }
+
+            exceptionMessage?.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", "path", "This is Path", "This is BaseUrl/This is Version/appKey/This is AppKey/path/This is Path/query/This is Query")]
+        [DataRow(null, "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", "path", "This is Path", "/{version}/appKey/{appKey}/path/{path}/query/{query}")]
+        [DataRow("This is BaseUrl", null, "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", "path", "This is Path", "This is BaseUrl/appKey/This is AppKey/path/This is Path/query/This is Query")]
+        [DataRow("This is BaseUrl", "This is Version", null, "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", "path", "This is Path", "This is BaseUrl/This is Version/appKey//path/This is Path/query/This is Query")]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", null, "query", "This is Query", "path", "This is Path", "This is BaseUrl/")]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", null, "This is Query", "path", "This is Path", "This is BaseUrl/This is Version/appKey/This is AppKey/path/This is Path/query/{query}")]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", null, "path", "This is Path", "This is BaseUrl/This is Version/appKey/This is AppKey/path/This is Path/query/")]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", null, "This is Path", "This is BaseUrl/This is Version/appKey/This is AppKey/path/{path}/query/This is Query")]
+        [DataRow("This is BaseUrl", "This is Version", "This is AppKey", "{version}/appKey/{appKey}/path/{path}/query/{query}", "query", "This is Query", "path", null, "This is BaseUrl/This is Version/appKey/This is AppKey/path//query/This is Query")]
+        public void Given_Parameters_When_Builder_Invoked_Then_It_Should_Return_Result(string baseUrl, string version, string appKey, string endpoint, string queryKey, string queryValue, string pahtKey, string pathValue, string expected)
+        {
+            var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
+            var headers = new RequestHeaderModel() { AppKey = appKey };
+            var queries = new JObject();
+            var paths = new string[] { pahtKey, pathValue };
+            try
+            {
+                queries.Add(queryKey, queryValue);
+            }
+            catch (Exception ex)
+            {
+                queries = null;
+            }
+            
+            
+
+            var requestUrl = new RequestUrlBuilder()
+             .WithSettings(settings, endpoint)
+             .WithHeaders(headers)
+             .WithQueries(queries)
+             .WithPaths(paths)
+             .Build();
+
+            requestUrl.Should().Be(expected);
+        }
+    }
+}

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -116,7 +116,7 @@ namespace Toast.Common.Tests.Builders
         }
 
         [TestMethod]
-        public void Given_Parameters_When_Build_Invoked_Then_It_Should_Return_Result()
+        public void Given_Default_RequestUrlBuilder_Instance_When_Build_Invoked_Then_It_Should_Return_Result()
         {
             var result = new RequestUrlBuilder().Build();
 

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -81,10 +81,10 @@ namespace Toast.Common.Tests.Builders
         }
 
         [DataTestMethod]
-        [DataRow("FakePath")]
-        [DataRow(null)]
-        [DataRow("")]
-        public void Given_Fake_Paths_Instance_When_WithPaths_Invoked_Then_It_Should_Return_Result(string path)
+        [DataRow("FakePath", 1)]
+        [DataRow(null, 0)]
+        [DataRow("", 1)]
+        public void Given_Fake_Paths_Instance_When_WithPaths_Invoked_Then_It_Should_Return_Result(string path, int count)
         {
             var settings = new ToastSettings() { };
             string endpoint = "";
@@ -93,11 +93,8 @@ namespace Toast.Common.Tests.Builders
             var resultPaths = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result) as Dictionary<string, string>;
             
             result.Should().BeOfType(typeof(RequestUrlBuilder));
-            if (string.IsNullOrWhiteSpace(path)) 
-            {
-                resultPaths.Keys.Should().Contain("fakePaths");
-                resultPaths.Values.Should().Contain(path);
-            }
+            resultPaths.Count.Should().Be(count);
+
             resultPaths.Should().BeOfType(typeof(Dictionary<string, string>));
         }
 

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -25,10 +25,41 @@ namespace Toast.Common.Tests.Builders
             var queriesFi = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance);
             var pathsFi = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            settingsFi?.FieldType.Name.Should().Be("ToastSettings");
-            endpointFi?.FieldType.Name.Should().Be("String");
-            queriesFi?.FieldType.Name.Should().Be("String");
-            pathsFi?.FieldType.Name.Should().Be("Dictionary`2");
+            if (settingsFi != null)
+            {
+                settingsFi.FieldType.Should().Be(typeof(ToastSettings));
+            }
+            else 
+            {
+                throw new AssertFailedException("Can't find Field _settings in RequestUrlBuilder instance");
+            }
+            
+            if (endpointFi != null)
+            {
+                endpointFi.FieldType.Should().Be(typeof(string));
+            }
+            else
+            {
+                throw new AssertFailedException("Can't find Field _endpoint in RequestUrlBuilder instance");
+            }
+
+            if (queriesFi != null)
+            {
+                queriesFi.FieldType.Should().Be(typeof(string));
+            }
+            else
+            {
+                throw new AssertFailedException("Can't find Field _queries in RequestUrlBuilder instance");
+            }
+
+            if (pathsFi != null) 
+            {
+                pathsFi.FieldType.Should().Be(typeof(Dictionary<string, string>));
+            }
+            else
+            {
+                throw new AssertFailedException("Can't find Field _paths in RequestUrlBuilder instance");
+            }
         }
 
         [TestMethod]
@@ -65,7 +96,7 @@ namespace Toast.Common.Tests.Builders
             var queries = new FakeRequestQuries();
             var result = new RequestUrlBuilder().WithSettings(settings, endpoint).WithQueries(queries);
             var resultQueries = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-
+            
             result.Should().BeOfType<RequestUrlBuilder>();
             resultQueries.Should().Be("");
         }

--- a/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
+++ b/test/NhnToast.Common.Tests/Builders/RequestUrlBuilderTests.cs
@@ -18,89 +18,52 @@ namespace Toast.Common.Tests.Builders
     public class RequestBuilderValidatorTests
     {
         [TestMethod]
-        public void Given_RequestUrlBuilder_Type_Then_It_Should_Contain_Properties()
+        public void Given_RequestUrlBuilder_Type_Then_It_Should_Contain_Fields()
         {
-            var fis = typeof(RequestUrlBuilder).GetProperties(BindingFlags.NonPublic|BindingFlags.Instance);
+            var SettingsFi = typeof(RequestUrlBuilder).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);
+            var EndpointFi = typeof(RequestUrlBuilder).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance);
+            var QueriesFi = typeof(RequestUrlBuilder).GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance);
+            var PathsFi = typeof(RequestUrlBuilder).GetField("_paths", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            fis.SingleOrDefault(p => p.Name == "_settings").Should().NotBeNull()
-                .And.Subject.PropertyType.Should().Be(typeof(ToastSettings));
-
-            fis.SingleOrDefault(p => p.Name == "_baseUrl").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(string));
-
-            fis.SingleOrDefault(p => p.Name == "_version").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(string));
-
-            fis.SingleOrDefault(p => p.Name == "_appKey").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(string));
-
-            fis.SingleOrDefault(p => p.Name == "_endpoint").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(string));
-
-            fis.SingleOrDefault(p => p.Name == "_queries").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(string));
-
-            fis.SingleOrDefault(p => p.Name == "_paths").Should().NotBeNull()
-               .And.Subject.PropertyType.Should().Be(typeof(Dictionary<string, string>));
+            SettingsFi?.FieldType.Name.Should().Be("ToastSettings");
+            EndpointFi?.FieldType.Name.Should().Be("String");
+            QueriesFi?.FieldType.Name.Should().Be("String");
+            PathsFi?.FieldType.Name.Should().Be("Dictionary`2");
         }
 
-        [DataTestMethod]
-        [DataRow("baseUrl", "version", "endpoint")]
-        [DataRow(null, null, null)]
-        [DataRow(null, "version", "endpoint")]
-        [DataRow("baseUrl", null, "endpoint")]
-        [DataRow("baseUrl", "version", null)]
-        public void Given_Parameters_When_WithSettins_Invoked_Then_It_Should_Return_Result(string baseUrl, string version, string endpoint)
+        [TestMethod]
+        public void Given_Default_Settings_When_WithSettins_Invoked_Then_It_Should_Return_Result()
         {
-            var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
-            var result = new RequestUrlBuilder().WithSettings(settings, endpoint);
+            var settings = new ToastSettings() { };
+            string endpoint = "";
 
-            var resultSetting = typeof(RequestUrlBuilder).GetProperty("_settings", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-            var resultBaseUrl = typeof(RequestUrlBuilder).GetProperty("_baseUrl", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-            var resultVersion = typeof(RequestUrlBuilder).GetProperty("_version", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-            var resultEndpoint = typeof(RequestUrlBuilder).GetProperty("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
+            var result = new RequestUrlBuilder().WithSettings(settings, endpoint);
+            var resultSetting = typeof(RequestUrlBuilder).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
+            var resultEndpoint = typeof(RequestUrlBuilder).GetField("_endpoint", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
             result.Should().BeOfType(typeof(RequestUrlBuilder));
-            resultSetting.Should().Be(resultSetting);
-            resultBaseUrl.Should().Be(baseUrl);
-            resultVersion.Should().Be(version);
+            resultSetting.Should().Be(settings);
             resultEndpoint.Should().Be(endpoint);
         }
 
-        [DataTestMethod]
-        [DataRow("appKey")]
-        [DataRow(null)]
-        public void Given_Parameters_When_WithHeaders_Invoked_Then_It_Should_Return_Result(string appKey)
+        [TestMethod]
+        public void Given_Default_Headers_When_WithHeaders_Invoked_Then_It_Should_Return_Result()
         {
-            var headers = new RequestHeaderModel() { AppKey = appKey };
+            var headers = new RequestHeaderModel() {};
             var result = new RequestUrlBuilder().WithHeaders(headers);
-            var resultAppKey = typeof(RequestUrlBuilder).GetProperty("_appKey", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
+            var resultHeader = typeof(RequestUrlBuilder).GetField("_headers", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
 
-            resultAppKey.Should().Be(appKey);
+            result.Should().BeOfType(typeof(RequestUrlBuilder));
+            resultHeader.Should().Be(headers);
         }
-
-        /*[TestMethod]
-        public void Given_InvalidQueries_When_WithQueries_Invoked_Then_It_Should_Throw_Exception( )
-        {
-            var settings = new ToastSettings();
-            var queries = new FakeRequestQuries2();
-            var result = new RequestUrlBuilder().WithSettings(settings, null).WithQueries(queries);
-
-            var resultQuery = typeof(RequestUrlBuilder).GetProperty("_queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-
-            result.Should().BeOfType<RequestUrlBuilder>();
-            resultQuery.Should().BeNull();
-        }*/
 
         [TestMethod]
         public void Given_Default_Queries_Instance_When_WithQueries_Invoked_Then_It_Should_Return_Result()
         {
             var queries = new FakeRequestQuries();
             var result = new RequestUrlBuilder().WithQueries(queries);
-            var resultQuery = typeof(RequestUrlBuilder).GetProperty("_queries", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
             
             result.Should().BeOfType<RequestUrlBuilder>();
-            resultQuery.Should().BeNull();
         }
 
         [TestMethod]
@@ -109,18 +72,26 @@ namespace Toast.Common.Tests.Builders
             var paths = new FakeRequestPaths();
             var result = new RequestUrlBuilder().WithPaths(paths);
 
-            var resultQuery = typeof(RequestUrlBuilder).GetProperty("_paths", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(result);
-
             result.Should().BeOfType<RequestUrlBuilder>();
-            resultQuery.Should().BeNull();
         }
 
-        [TestMethod]
-        public void Given_Default_RequestUrlBuilder_Instance_When_Build_Invoked_Then_It_Should_Return_Result()
+        [DataTestMethod]
+        [DataRow("https://api-sms.cloud.toast.com/", "/sms/{version}/appKeys/{appKey}/sender/sms", "v3.0", "appKey", "https://api-sms.cloud.toast.com/sms/v3.0/appKeys/appKey/sender/sms")]
+        public void Given_Default_RequestUrlBuilder_Instance_When_Build_Invoked_Then_It_Should_Return_Result(string baseUrl, string endpoint, string version, string appKey, string expected)
         {
-            var result = new RequestUrlBuilder().Build();
+            var settings = new ToastSettings() { BaseUrl = baseUrl, Version = version };
+            var headers = new RequestHeaderModel() { AppKey = appKey};
+            var queries = new FakeRequestQuries();
+            var paths = new FakeRequestPaths();
 
-            result.Should().BeOfType(typeof(string));
+            var result = new RequestUrlBuilder()
+                .WithSettings(settings, endpoint)
+                .WithHeaders(headers)
+                .WithQueries(queries)
+                .WithPaths(paths)
+                .Build();
+
+            result.Should().Be(expected);
         }
     }
 }

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
@@ -5,8 +5,4 @@ namespace Toast.Common.Tests.Fakes
     public class FakeRequestPaths : BaseRequestPaths
     {
     }
-
-    public class FakeRequestPaths2
-    {
-    }
 }

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
@@ -4,5 +4,6 @@ namespace Toast.Common.Tests.Fakes
 {
     public class FakeRequestPaths : BaseRequestPaths
     {
+        public string FakePaths { get; set; }
     }
 }

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestPaths.cs
@@ -1,0 +1,12 @@
+using Toast.Common.Models;
+
+namespace Toast.Common.Tests.Fakes
+{
+    public class FakeRequestPaths : BaseRequestPaths
+    {
+    }
+
+    public class FakeRequestPaths2
+    {
+    }
+}

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
@@ -5,8 +5,4 @@ namespace Toast.Common.Tests.Fakes
     public class FakeRequestQuries : BaseRequestQueries
     {
     }
-
-    public class FakeRequestQuries2 : BaseRequestQueries
-    {
-    }
 }

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
@@ -1,0 +1,12 @@
+using Toast.Common.Models;
+
+namespace Toast.Common.Tests.Fakes
+{
+    public class FakeRequestQuries : BaseRequestQueries
+    {
+    }
+
+    public class FakeRequestQuries2 : BaseRequestQueries
+    {
+    }
+}

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
@@ -4,6 +4,7 @@ namespace Toast.Common.Tests.Fakes
 {
     public class FakeRequestQuries : BaseRequestQueries
     {
-        public string FakeQueries { get; set; }
+        public string FakeQuery1 { get; set; }
+        public string FakeQuery2 { get; set; }
     }
 }

--- a/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
+++ b/test/NhnToast.Common.Tests/Fakes/FakeRequestQueries.cs
@@ -4,5 +4,6 @@ namespace Toast.Common.Tests.Fakes
 {
     public class FakeRequestQuries : BaseRequestQueries
     {
+        public string FakeQueries { get; set; }
     }
 }

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -9,14 +9,13 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
 using Toast.Sms.Tests.Configurations;
 using Toast.Tests.Common.Configurations;
-
-using WorldDomination.Net.Http;
 
 namespace Toast.Sms.Tests.Triggers
 {
@@ -52,14 +51,21 @@ namespace Toast.Sms.Tests.Triggers
         public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int? recipientSeq, bool expected)
         {
             // Arrange
-            var options = new GetMessageRequestUrlOptions()
+            GetMessageRequestQueries queries = null;
+            if (recipientSeq != null)
             {
-                Version = this._settings.Version,
-                AppKey = this._headers.AppKey,
-                RequestId = useRequestId ? this._settings.Examples.RequestId : null,
-                RecipientSeq = recipientSeq
-            };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.GetMessage.TrimStart('/')}", options);
+                queries = new GetMessageRequestQueries() { RecipientSequenceNumber = (int)recipientSeq };
+            }
+            
+            string[] paths = new string[] {"requestId", useRequestId ? this._settings.Examples.RequestId : null};
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)
+                .WithHeaders(this._headers)
+                .WithQueries(queries)
+                .WithPaths(paths)
+                .Build();
+
 
             var http = new HttpClient();
 

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -51,11 +51,9 @@ namespace Toast.Sms.Tests.Triggers
         public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int? recipientSeq, bool expected)
         {
             // Arrange
-            GetMessageRequestQueries queries = null;
-            if (recipientSeq != null)
-            {
-                queries = new GetMessageRequestQueries() { RecipientSequenceNumber = (int)recipientSeq };
-            }
+            
+            GetMessageRequestQueries queries = new GetMessageRequestQueries();
+            if (recipientSeq is not null) queries.RecipientSequenceNumber = (int)recipientSeq;
 
             var paths = new GetMessageRequestPaths() { RequestId = useRequestId ? this._settings.Examples.RequestId : null };
             var requestUrl = new RequestUrlBuilder()

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -43,18 +43,16 @@ namespace Toast.Sms.Tests.Triggers
 
         [TestCategory("Integration")]
         [DataTestMethod]
-        [DataRow(false, null, false)]
+        //[DataRow(false, null, false)]
         [DataRow(false, 1, false)]
-        [DataRow(true, null, false)]
+        //[DataRow(true, null, false)]
         [DataRow(true, 1, true)]
         [DataRow(true, 100, true)]
-        public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int? recipientSeq, bool expected)
+        public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int recipientSeq, bool expected)
         {
             // Arrange  
-            GetMessageRequestQueries? queries = new GetMessageRequestQueries();
-            if (recipientSeq is not null) queries.RecipientSequenceNumber = (int)recipientSeq;
-            else queries = null;
-
+            GetMessageRequestQueries? queries = new GetMessageRequestQueries() { RecipientSequenceNumber = recipientSeq };
+            
             var paths = new GetMessageRequestPaths() { RequestId = useRequestId ? this._settings.Examples.RequestId : null };
             var requestUrl = new RequestUrlBuilder()
                 .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -43,9 +43,7 @@ namespace Toast.Sms.Tests.Triggers
 
         [TestCategory("Integration")]
         [DataTestMethod]
-        //[DataRow(false, null, false)]
         [DataRow(false, 1, false)]
-        //[DataRow(true, null, false)]
         [DataRow(true, 1, true)]
         [DataRow(true, 100, true)]
         public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int recipientSeq, bool expected)

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -50,8 +50,7 @@ namespace Toast.Sms.Tests.Triggers
         [DataRow(true, 100, true)]
         public async Task Given_Parameters_When_GetMessage_Invoked_Then_It_Should_Return_Result(bool useRequestId, int? recipientSeq, bool expected)
         {
-            // Arrange
-            
+            // Arrange  
             GetMessageRequestQueries? queries = new GetMessageRequestQueries();
             if (recipientSeq is not null) queries.RecipientSequenceNumber = (int)recipientSeq;
             else queries = null;

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -52,8 +52,9 @@ namespace Toast.Sms.Tests.Triggers
         {
             // Arrange
             
-            GetMessageRequestQueries queries = new GetMessageRequestQueries();
+            GetMessageRequestQueries? queries = new GetMessageRequestQueries();
             if (recipientSeq is not null) queries.RecipientSequenceNumber = (int)recipientSeq;
+            else queries = null;
 
             var paths = new GetMessageRequestPaths() { RequestId = useRequestId ? this._settings.Examples.RequestId : null };
             var requestUrl = new RequestUrlBuilder()

--- a/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/GetMessageTests.cs
@@ -56,9 +56,8 @@ namespace Toast.Sms.Tests.Triggers
             {
                 queries = new GetMessageRequestQueries() { RecipientSequenceNumber = (int)recipientSeq };
             }
-            
-            string[] paths = new string[] {"requestId", useRequestId ? this._settings.Examples.RequestId : null};
 
+            var paths = new GetMessageRequestPaths() { RequestId = useRequestId ? this._settings.Examples.RequestId : null };
             var requestUrl = new RequestUrlBuilder()
                 .WithSettings<ToastSettings>(this._settings, this._settings.Endpoints.GetMessage)
                 .WithHeaders(this._headers)

--- a/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
@@ -56,7 +56,7 @@ namespace Toast.Sms.Tests.Triggers
         public async Task Given_Parameters_When_ListMessagesStatus_Invoked_Then_It_Should_Return_Result(string startUpdateDate, string endUpdatedate, string? messageType, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
-            ListMessageStatusRequestQuries queries = new ListMessageStatusRequestQuries()
+            ListMessageStatusRequestQueries queries = new ListMessageStatusRequestQueries()
             {
                 StartUpdateDate = startUpdateDate,
                 EndUpdateDate = endUpdatedate,

--- a/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
@@ -57,18 +57,6 @@ namespace Toast.Sms.Tests.Triggers
         public async Task Given_Parameters_When_ListMessagesStatus_Invoked_Then_It_Should_Return_Result(string startUpdateDate, string endUpdatedate, string? messageType, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
-            /*var options = new ListMessageStatusRequestUrlOptions()
-            {
-                Version = this._settings.Version,
-                AppKey = this._headers.AppKey,
-                StartUpdateDate = startUpdateDate,
-                EndUpdateDate = endUpdatedate,
-                MessageType = messageType,
-                PageNum = pageNum,
-                PageSize = pageSize
-            };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessageStatus.TrimStart('/')}", options);*/
-
             ListMessageStatusRequestQuries queries = new ListMessageStatusRequestQuries()
             {
                 StartUpdateDate = startUpdateDate,

--- a/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
@@ -51,9 +51,8 @@ namespace Toast.Sms.Tests.Triggers
         [DataRow("2018-10-04 16:16:00", null, "MMS", 1, 15, false)]
         [DataRow(null, null, "MMS", 1, 15, false)]
         [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", null, 1, 15, true)]
-        [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", null, 0, 15, true)]
-        [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", "SMS", null, 15, false)]
-        [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", "SMS", 1, null, false)]
+        [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", "SMS", null, 15, true)]
+        [DataRow("2018-10-04 16:16:00", "2018-10-04 16:17:10", "SMS", 1, null, true)]
         public async Task Given_Parameters_When_ListMessagesStatus_Invoked_Then_It_Should_Return_Result(string startUpdateDate, string endUpdatedate, string? messageType, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
@@ -62,8 +61,8 @@ namespace Toast.Sms.Tests.Triggers
                 StartUpdateDate = startUpdateDate,
                 EndUpdateDate = endUpdatedate,
                 MessageType = messageType,
-                PageNumber = pageNum,
-                PageSize = pageSize,
+                PageNum = (pageNum != null) ? pageNum : 1,
+                PageSize = (pageSize != null) ? pageSize : 15,
             };
             
 

--- a/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
@@ -9,14 +9,13 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
 using Toast.Sms.Tests.Configurations;
 using Toast.Tests.Common.Configurations;
-
-using WorldDomination.Net.Http;
 
 namespace Toast.Sms.Tests.Triggers
 {
@@ -58,7 +57,7 @@ namespace Toast.Sms.Tests.Triggers
         public async Task Given_Parameters_When_ListMessagesStatus_Invoked_Then_It_Should_Return_Result(string startUpdateDate, string endUpdatedate, string? messageType, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
-            var options = new ListMessageStatusRequestUrlOptions()
+            /*var options = new ListMessageStatusRequestUrlOptions()
             {
                 Version = this._settings.Version,
                 AppKey = this._headers.AppKey,
@@ -68,7 +67,22 @@ namespace Toast.Sms.Tests.Triggers
                 PageNum = pageNum,
                 PageSize = pageSize
             };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessageStatus.TrimStart('/')}", options);
+            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessageStatus.TrimStart('/')}", options);*/
+
+            ListMessageStatusRequestQuries queries = new ListMessageStatusRequestQuries()
+            {
+                StartUpdateDate = startUpdateDate,
+                EndUpdateDate = endUpdatedate,
+                MessageType = messageType,
+                PageNumber = pageNum,
+                PageSize = pageSize,
+            };
+            
+
+            var requestUrl = new RequestUrlBuilder()
+               .WithSettings(this._settings, this._settings.Endpoints.ListMessageStatus)
+               .WithHeaders(this._headers).WithQueries(queries)
+               .Build();
 
             var http = new HttpClient();
 

--- a/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/LIstMessageStatusTests.cs
@@ -61,7 +61,7 @@ namespace Toast.Sms.Tests.Triggers
                 StartUpdateDate = startUpdateDate,
                 EndUpdateDate = endUpdatedate,
                 MessageType = messageType,
-                PageNum = (pageNum != null) ? pageNum : 1,
+                PageNumber = (pageNum != null) ? pageNum : 1,
                 PageSize = (pageSize != null) ? pageSize : 15,
             };
             

--- a/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
@@ -107,7 +107,7 @@ namespace Toast.Sms.Tests.Triggers
                 SubResultCode = subResultCode,
                 SenderGroupingKey = senderGroupingKey,
                 RecipientGroupingKey = recipientGroupingKey,
-                PageNum = (pageNum != null) ? pageNum : 1,
+                PageNumber = (pageNum != null) ? pageNum : 1,
                 PageSize = (pageSize != null) ? pageSize : 15,
             };
             var requestUrl = new RequestUrlBuilder()

--- a/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
@@ -55,9 +55,9 @@ namespace Toast.Sms.Tests.Triggers
         [DataRow(false, "2022-03-22 18:00:00", null, null, "2022-03-22 22:00:00", null, null, null, null, null, null, null, null, null, null, 1, 15, false)]
         [DataRow(false, null, "2022-03-22 22:00:00", "2022-03-22 18:00:00", null, null, null, null, null, null, null, null, null, null, null, 1, 15, false)]
         [DataRow(false, null, "2022-03-22 22:00:00", null, "2022-03-22 18:00:00", null, null, null, null, null, null, null, null, null, null, 1, 15, false)]
-        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, null, false)]
-        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 15, false)]
+        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, true)]
+        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, null, true)]
+        [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 15, true)]
         [DataRow(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, 15, true)]
         [DataRow(true, null, null, "2022-03-22 22:00:00", "2022-03-22 18:00:00", null, null, null, null, null, null, null, null, null, null, 1, 15, true)]
         [DataRow(true, "2022-03-22 18:00:00", "2022-03-22 22:00:00", null, null, null, null, null, null, null, null, null, null, null, null, 1, 15, true)]
@@ -107,9 +107,9 @@ namespace Toast.Sms.Tests.Triggers
                 SubResultCode = subResultCode,
                 SenderGroupingKey = senderGroupingKey,
                 RecipientGroupingKey = recipientGroupingKey,
-                PageNum = pageNum,
-                PageSize = pageSize,
-        };
+                PageNum = (pageNum != null) ? pageNum : 1,
+                PageSize = (pageSize != null) ? pageSize : 15,
+            };
             var requestUrl = new RequestUrlBuilder()
                 .WithSettings(this._settings, this._settings.Endpoints.ListMessages)
                 .WithHeaders(this._headers).WithQueries(queries)

--- a/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
@@ -131,7 +131,7 @@ namespace Toast.Sms.Tests.Triggers
                 SubResultCode = subResultCode,
                 SenderGroupingKey = senderGroupingKey,
                 RecipientGroupingKey = recipientGroupingKey,
-                PageNumber = pageNum,
+                PageNum = pageNum,
                 PageSize = pageSize,
         };
             var requestUrl = new RequestUrlBuilder()

--- a/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
@@ -90,30 +90,6 @@ namespace Toast.Sms.Tests.Triggers
             string startResultDate, string endResultDate, string sendNo, string recipientNo, string templateId, string msgStatus, string resultCode, string subResultCode, string senderGroupingKey, string recipientGroupingKey, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
-            /*var options = new ListMessagesRequestUrlOptions()
-            {
-                Version = this._settings.Version,
-                AppKey = this._headers.AppKey,
-                RequestId = useRequestId ? this._settings.Examples.RequestId : null,
-                StartRequestDate = startRequestDate,
-                EndRequestDate = endRequestDate,
-                StartCreateDate = startCreateDate,
-                EndCreateDate = endCreateDate,
-                StartResultDate = startResultDate,
-                EndResultDate = endResultDate,
-                SendNo = sendNo,
-                RecipientNo = recipientNo,
-                TemplateId = templateId,
-                MsgStatus = msgStatus,
-                ResultCode = resultCode,
-                SubResultCode = subResultCode,
-                SenderGroupingKey = senderGroupingKey,
-                RecipientGroupingKey = recipientGroupingKey,
-                PageNum = pageNum,
-                PageSize = pageSize
-            };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessages.TrimStart('/')}", options);*/
-
             ListMessagesRequestQueries queries = new ListMessagesRequestQueries()
             {
                 RequestId = useRequestId ? this._settings.Examples.RequestId : null,

--- a/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/ListMessagesTests.cs
@@ -9,14 +9,13 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
 using Toast.Sms.Tests.Configurations;
 using Toast.Tests.Common.Configurations;
-
-using WorldDomination.Net.Http;
 
 namespace Toast.Sms.Tests.Triggers
 {
@@ -91,7 +90,7 @@ namespace Toast.Sms.Tests.Triggers
             string startResultDate, string endResultDate, string sendNo, string recipientNo, string templateId, string msgStatus, string resultCode, string subResultCode, string senderGroupingKey, string recipientGroupingKey, int? pageNum, int? pageSize, bool expected)
         {
             // Arrange
-            var options = new ListMessagesRequestUrlOptions()
+            /*var options = new ListMessagesRequestUrlOptions()
             {
                 Version = this._settings.Version,
                 AppKey = this._headers.AppKey,
@@ -113,7 +112,32 @@ namespace Toast.Sms.Tests.Triggers
                 PageNum = pageNum,
                 PageSize = pageSize
             };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessages.TrimStart('/')}", options);
+            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.ListMessages.TrimStart('/')}", options);*/
+
+            ListMessagesRequestQueries queries = new ListMessagesRequestQueries()
+            {
+                RequestId = useRequestId ? this._settings.Examples.RequestId : null,
+                StartRequestDate = startRequestDate,
+                EndRequestDate = endRequestDate,
+                StartCreateDate = startCreateDate,
+                EndCreateDate = endCreateDate,
+                StartResultDate = startResultDate,
+                EndResultDate = endResultDate,
+                SendNumber = sendNo,
+                RecipientNumber = recipientNo,
+                TemplateId = templateId,
+                MessageStatus = msgStatus,
+                ResultCode = resultCode,
+                SubResultCode = subResultCode,
+                SenderGroupingKey = senderGroupingKey,
+                RecipientGroupingKey = recipientGroupingKey,
+                PageNumber = pageNum,
+                PageSize = pageSize,
+        };
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(this._settings, this._settings.Endpoints.ListMessages)
+                .WithHeaders(this._headers).WithQueries(queries)
+                .Build();
 
             var http = new HttpClient();
 

--- a/test/NhnToast.Sms.Tests/Triggers/SendMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/SendMessagesTests.cs
@@ -57,13 +57,7 @@ namespace Toast.Sms.Tests.Triggers
             var sendNo = useSendNo ? this._settings.Examples.SendNo : null;
             var recipientNo = useRecipientNo ? this._settings.Examples.RecipientNo : null;
             var json = $"{{ \"body\": \"{body}\", \"sendNo\": \"{sendNo}\", \"recipientList\": [ {{\"recipientNo\": \"{recipientNo}\" }} ] }}";
-            /*var options = new RequestUrlOptions
-            {
-                Version = this._settings.Version,
-                AppKey = this._headers.AppKey
-            };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.SendMessages.TrimStart('/')}", options);*/
-
+            
             var requestUrl = new RequestUrlBuilder()
                 .WithSettings(this._settings, this._settings.Endpoints.SendMessages)
                 .WithHeaders(this._headers)

--- a/test/NhnToast.Sms.Tests/Triggers/SendMessagesTests.cs
+++ b/test/NhnToast.Sms.Tests/Triggers/SendMessagesTests.cs
@@ -10,13 +10,12 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Toast.Common.Builders;
 using Toast.Common.Configurations;
 using Toast.Common.Models;
 using Toast.Sms.Configurations;
 using Toast.Sms.Tests.Configurations;
 using Toast.Tests.Common.Configurations;
-
-using WorldDomination.Net.Http;
 
 namespace Toast.Sms.Tests.Triggers
 {
@@ -58,12 +57,17 @@ namespace Toast.Sms.Tests.Triggers
             var sendNo = useSendNo ? this._settings.Examples.SendNo : null;
             var recipientNo = useRecipientNo ? this._settings.Examples.RecipientNo : null;
             var json = $"{{ \"body\": \"{body}\", \"sendNo\": \"{sendNo}\", \"recipientList\": [ {{\"recipientNo\": \"{recipientNo}\" }} ] }}";
-            var options = new RequestUrlOptions
+            /*var options = new RequestUrlOptions
             {
                 Version = this._settings.Version,
                 AppKey = this._headers.AppKey
             };
-            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.SendMessages.TrimStart('/')}", options);
+            var requestUrl = this._settings.Formatter.Format($"{this._settings.BaseUrl.TrimEnd('/')}/{this._settings.Endpoints.SendMessages.TrimStart('/')}", options);*/
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(this._settings, this._settings.Endpoints.SendMessages)
+                .WithHeaders(this._headers)
+                .Build();
 
             var http = new HttpClient();
 


### PR DESCRIPTION
RequestUrlBuilder 구현 및 단위 테스트 추가했습니다.

options를 사용하지 않고 URL을 만드는 과정에서 Endpoint의 이름과 RequestQuries 멤버의 이름을 일치하기 위해 JSONProperty를 추가했습니다.
paths는 빌더를 호출하는 task에서 이름과 값을 string[] 형태로 넘겨주는 형식으로 구현했습니다.

단위 테스트 부분이 DataRow에 quries나 header를 넘겨주지 못해서 string으로 처리하다 보니 억지로 끼워 맞춘거 같은데 개선 할 수 있는 방법이 있으까요?