### PR TITLE
인증 방식 변경

### DIFF
--- a/infra/apiManagementApi.bicep
+++ b/infra/apiManagementApi.bicep
@@ -206,6 +206,18 @@ resource apimapipolicy 'Microsoft.ApiManagement/service/apis/policies@2021-08-01
 
 var operations = [
     {
+        name: 'openapi-v2-json'
+        displayName: 'openapi/v2.json'
+        method: 'GET'
+        urlTemplate: '/openapi/v2.json'
+    }
+    {
+        name: 'openapi-v3-json'
+        displayName: 'openapi/v3.json'
+        method: 'GET'
+        urlTemplate: '/openapi/v3.json'
+    }
+    {
         name: 'swagger-json'
         displayName: 'swagger.json'
         method: 'GET'

--- a/infra/provision-apiManagementApi.json
+++ b/infra/provision-apiManagementApi.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.6.18.56646",
-      "templateHash": "4806279195893736076"
+      "templateHash": "13562727815394432639"
     }
   },
   "parameters": {
@@ -173,7 +173,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.6.18.56646",
-              "templateHash": "14378244657716164852"
+              "templateHash": "10031038445999354079"
             }
           },
           "parameters": {
@@ -371,6 +371,18 @@
               "productName": "[parameters('apiMgmtProductName')]"
             },
             "operations": [
+              {
+                "name": "openapi-v2-json",
+                "displayName": "openapi/v2.json",
+                "method": "GET",
+                "urlTemplate": "/openapi/v2.json"
+              },
+              {
+                "name": "openapi-v3-json",
+                "displayName": "openapi/v3.json",
+                "method": "GET",
+                "urlTemplate": "/openapi/v3.json"
+              },
               {
                 "name": "swagger-json",
                 "displayName": "swagger.json",

--- a/infra/setup-apim.sh
+++ b/infra/setup-apim.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+sleep 30s
+
 declare -a fncapp_suffixes
 suffix_index=1
 

--- a/src/nt-common/Extensions/HttpRequestExtensions.cs
+++ b/src/nt-common/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Text;
+
+using Microsoft.AspNetCore.Http;
+
+using Toast.Common.Models;
+
+namespace Toast.Common.Extensions
+{
+    public static class HttpRequestExtensions
+    {
+        public static T To<T>(this HttpRequest req, bool useBasicAuthHeader) where T : RequestHeaderModel
+        {
+            var values = req.Headers["Authorization"]
+                            .ToString()
+                            .Replace("Basic", string.Empty)
+                            .Trim()
+                            .Decode()
+                            .Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries)
+                            .ToArray();
+
+            var headers = new RequestHeaderModel() { AppKey = values.First(), SecretKey = values.Last() };
+
+            return (T)headers;
+        }
+
+        private static string Decode(this string base64EncodedValue)
+        {
+            var bytes = Convert.FromBase64String(base64EncodedValue);
+            var decoded = Encoding.UTF8.GetString(bytes);
+
+            return decoded;
+        }
+    }
+}

--- a/src/nt-common/NhnToast.Common.csproj
+++ b/src/nt-common/NhnToast.Common.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SmartFormat" Version="3.0.0" />
   </ItemGroup>

--- a/src/nt-common/Validators/RequestHeaderValidator.cs
+++ b/src/nt-common/Validators/RequestHeaderValidator.cs
@@ -20,16 +20,28 @@ namespace Toast.Common.Validators
         public static async Task<RequestHeaderModel> Validate(this Task<RequestHeaderModel> headers)
         {
             var instance = await headers.ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(instance.AppKey))
+
+            return Validate(instance);
+        }
+
+        /// <summary>
+        /// Validates the request header.
+        /// </summary>
+        /// <param name="headers"><see cref="RequestHeaderModel"/> instance.</param>
+        /// <returns>Returns the <see cref="RequestHeaderModel"/> instance.</returns>
+        /// <remarks>This method will throw <see cref="RequestHeaderNotValidException"/> if the request header is invalid.</remarks>
+        public static RequestHeaderModel Validate(this RequestHeaderModel headers)
+        {
+            if (string.IsNullOrWhiteSpace(headers.AppKey))
             {
                 throw new RequestHeaderNotValidException("Not Found") { StatusCode = HttpStatusCode.NotFound };
             }
-            if (string.IsNullOrWhiteSpace(instance.SecretKey))
+            if (string.IsNullOrWhiteSpace(headers.SecretKey))
             {
                 throw new RequestHeaderNotValidException("Unauthorized") { StatusCode = HttpStatusCode.Unauthorized };
             }
 
-            return instance;
+            return headers;
         }
     }
 }

--- a/src/nt-sms-verify/Triggers/ListSenders.cs
+++ b/src/nt-sms-verify/Triggers/ListSenders.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
 using Toast.Common.Configurations;
+using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Verification.Configurations;
@@ -58,9 +59,10 @@ namespace Toast.Sms.Verification.Triggers
         /// <returns>Returns the <see cref="IActionResult"/> instance that contains the list of sender's phone numbers.</returns>
         [FunctionName(nameof(ListSenders))]
         [OpenApiOperation(operationId: "Senders.List", tags: new[] { "senders" })]
-        [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
-        [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
+        [OpenApiSecurity("app_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic, Description = "Toast API basic auth")]
+        // [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
+        // [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
+        // [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
         [OpenApiParameter(name: "sendNo", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "Sender's phone number")]
         [OpenApiParameter(name: "useYn", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "Value indicating whether the number is used or not")]
         [OpenApiParameter(name: "blockYn", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "Value indicating whether the number is blocked or not")]
@@ -77,7 +79,8 @@ namespace Toast.Sms.Verification.Triggers
             var headers = default(RequestHeaderModel);
             try
             {
-                headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
+                headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true).Validate();
+                // headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms-verify/local.settings.sample.json
+++ b/src/nt-sms-verify/local.settings.sample.json
@@ -4,6 +4,10 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
+    "OpenApi__Version": "v3",
+    "OpenApi__DocTitle": "NHN Cloud SMS Verification API",
+    "OpenApi__DocVersion": "v1.0.0",
+
     "Toast__BaseUrl": "https://api-sms.cloud.toast.com/",
     "Toast__Version": "v3.0",
     "Toast__Endpoints__ListSenders": "/sms/{version}/appKeys/{appKey}/sendNos?sendNo={sendNo}&useYn={useYn}&blockYn={blockYn}&pageNum={pageNum}&pageSize={pageSize}"

--- a/src/nt-sms/Triggers/GetMessage.cs
+++ b/src/nt-sms/Triggers/GetMessage.cs
@@ -19,6 +19,7 @@ using Microsoft.OpenApi.Models;
 
 using Toast.Common.Builders;
 using Toast.Common.Configurations;
+using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
@@ -44,9 +45,10 @@ namespace Toast.Sms.Triggers
 
         [FunctionName(nameof(GetMessage))]
         [OpenApiOperation(operationId: "Messages.Get", tags: new[] { "messages" })]
-        [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
-        [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
+        [OpenApiSecurity("app_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic, Description = "Toast API basic auth")]
+        // [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
+        // [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
+        // [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
         [OpenApiParameter(name: "requestId", Type = typeof(string), In = ParameterLocation.Path, Required = true, Description = "SMS request ID")]
         [OpenApiParameter(name: "recipientSeq", Type = typeof(int), In = ParameterLocation.Query, Required = true, Description = "SMS request sequence number")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(GetMessageResponse), Example = typeof(GetMessageResponseModelExample), Description = "The OK response")]
@@ -61,7 +63,8 @@ namespace Toast.Sms.Triggers
             var headers = default(RequestHeaderModel);
             try
             {
-                headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
+                headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true).Validate();
+                // headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms/Triggers/ListMessageStatus.cs
+++ b/src/nt-sms/Triggers/ListMessageStatus.cs
@@ -19,6 +19,7 @@ using Microsoft.OpenApi.Models;
 
 using Toast.Common.Builders;
 using Toast.Common.Configurations;
+using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
@@ -44,9 +45,10 @@ namespace Toast.Sms.Triggers
 
         [FunctionName(nameof(ListMessageStatus))]
         [OpenApiOperation(operationId: "Messages.Status", tags: new[] { "messages" })]
-        [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
-        [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
+        [OpenApiSecurity("app_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic, Description = "Toast API basic auth")]
+        // [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header, Description = "Toast app key")]
+        // [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header, Description = "Toast secret key")]
+        // [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header, Description = "Functions API key")]
         [OpenApiParameter(name: "startUpdateDate", Type = typeof(string), In = ParameterLocation.Query, Required = true, Description = "StartDate for message list (`yyyy-MM-dd HH:mm:ss`)")]
         [OpenApiParameter(name: "endUpdateDate", Type = typeof(string), In = ParameterLocation.Query, Required = true, Description = "endDate for message list (`yyyy-MM-dd HH:mm:ss`)")]
         [OpenApiParameter(name: "messageType", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "message type (`SMS`/`LMS`/`MMS`/`AUTH`)")]
@@ -63,7 +65,8 @@ namespace Toast.Sms.Triggers
             var headers = default(RequestHeaderModel);
             try
             {
-                headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
+                headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true).Validate();
+                // headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms/Triggers/ListMessages.cs
+++ b/src/nt-sms/Triggers/ListMessages.cs
@@ -19,6 +19,7 @@ using Microsoft.OpenApi.Models;
 
 using Toast.Common.Builders;
 using Toast.Common.Configurations;
+using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
@@ -44,9 +45,10 @@ namespace Toast.Sms.Triggers
 
         [FunctionName(nameof(ListMessages))]
         [OpenApiOperation(operationId: "Messages.List", tags: new[] { "messages" })]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
-        [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header)]
-        [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header)]
+        [OpenApiSecurity("app_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic, Description = "Toast API basic auth")]
+        // [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header)]
+        // [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header)]
+        // [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
         [OpenApiParameter(name: "requestId", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "RequestId to search. `requestId` or `startRequestDate` + `endRequestDate` or `startCreateDate` + `endCreateDate` must be filled")]
         [OpenApiParameter(name: "startRequestDate", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "Message sending request start date (`yyyy-MM-dd HH:mm:ss`)")]
         [OpenApiParameter(name: "endRequestDate", Type = typeof(string), In = ParameterLocation.Query, Required = false, Description = "Message sending request end date (`yyyy-MM-dd HH:mm:ss`)")]
@@ -75,7 +77,8 @@ namespace Toast.Sms.Triggers
             var headers = default(RequestHeaderModel);
             try
             {
-                headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
+                headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true).Validate();
+                // headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms/Triggers/SendMessages.cs
+++ b/src/nt-sms/Triggers/SendMessages.cs
@@ -20,6 +20,7 @@ using Microsoft.OpenApi.Models;
 
 using Toast.Common.Builders;
 using Toast.Common.Configurations;
+using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
@@ -45,9 +46,10 @@ namespace Toast.Sms.Triggers
 
         [FunctionName(nameof(SendMessages))]
         [OpenApiOperation(operationId: "Messages.Send", tags: new[] { "messages" })]
-        [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header)]
-        [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header)]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
+        [OpenApiSecurity("app_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic, Description = "Toast API basic auth")]
+        // [OpenApiSecurity("app_key", SecuritySchemeType.ApiKey, Name = "x-app-key", In = OpenApiSecurityLocationType.Header)]
+        // [OpenApiSecurity("secret_key", SecuritySchemeType.ApiKey, Name = "x-secret-key", In = OpenApiSecurityLocationType.Header)]
+        // [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
         [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(SendMessagesRequestBody), Example = typeof(SendMessagesRequestBodyModelExample), Description = "Message payload to send")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(SendMessagesResponse),  Example = typeof(SendMessagesResponseModelExample), Description = "The OK response")]
         [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.BadRequest, Description = "The input was invalid")]
@@ -60,7 +62,8 @@ namespace Toast.Sms.Triggers
             var headers = default(RequestHeaderModel);
             try
             {
-                headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
+                headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true).Validate();
+                // headers = await req.To<RequestHeaderModel>(SourceFrom.Header).Validate().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/nt-sms/local.settings.sample.json
+++ b/src/nt-sms/local.settings.sample.json
@@ -4,6 +4,10 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
+    "OpenApi__Version": "v3",
+    "OpenApi__DocTitle": "NHN Cloud SMS API",
+    "OpenApi__DocVersion": "v1.0.0",
+
     "Toast__BaseUrl": "https://api-sms.cloud.toast.com/",
     "Toast__Version": "v3.0",
     "Toast__Endpoints__SendMessages": "/sms/{version}/appKeys/{appKey}/sender/sms",


### PR DESCRIPTION
* 기존의 x-app-key, x-secret-key 모델을 사용할 경우 파워 플랫폼 커스텀 커넥터에서 두 개의 키를 동시에 읽어들일 수 없는 오류 발견
* 이 PR을 통해 appKey와 secretKey를 basic auth 방식을 통해 제공하는 방식으로 변경
