### PR TITLE
Modify Regex Dependency in Validator Class

### DIFF
--- a/src/nt-sms/Startup.cs
+++ b/src/nt-sms/Startup.cs
@@ -45,6 +45,7 @@ namespace Toast.Sms
 
         private static void ConfigureValidators(IServiceCollection services)
         {
+            services.AddSingleton<IRegexDateTimeWrapper, RegexDateTimeWrapper>();
             services.AddScoped<IValidator<GetMessageRequestQueries>, GetMessageRequestQueryValidator>();
             services.AddScoped<IValidator<ListMessagesRequestQueries>, ListMessagesRequestQueryValidator>();
             services.AddScoped<IValidator<ListMessageStatusRequestQueries>, ListMessageStatusRequestQueryValidator>();

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -42,13 +42,16 @@ namespace Toast.Sms.Validators
     /// </summary>
     public class ListMessageStatusRequestQueryValidator : AbstractValidator<ListMessageStatusRequestQueries>
     {
+        private readonly IRegexDateTimeWrapper _regex;
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessageStatusRequestQueryValidator"/> class.
         /// </summary>
-        public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
+        public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this.RuleFor(p => p.StartUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty();
-            this.RuleFor(p => p.EndUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty().GreaterThan(q => q.StartUpdateDate);
+            this._regex = regex;
+
+            this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
+            this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);
             When(p => p.MessageType != null, () =>
             {
                 this.RuleFor(p => p.MessageType).Must(p => MsgType.Contains(p));
@@ -57,6 +60,19 @@ namespace Toast.Sms.Validators
             this.RuleFor(p => p.PageSize).GreaterThan(0);
 
         }
+
+        private bool IsValidDateFormat(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return this._regex.IsMatch(date);
+            }
+        }
+        
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };
     }
 }

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -64,7 +64,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return _regex.IsMatch(date);
+            return this._regex.IsMatch(date);
         }
 
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -48,7 +48,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
+            this._regex = (regex == null) ? new RegexDateTimeWrapper() : regex ;
 
             this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
             this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);
@@ -63,7 +63,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return date != null ? _regex.IsMatch(date) : false ;
+            return (date != null) ? _regex.IsMatch(date) : false ;
         }
         
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -7,6 +7,7 @@ using FluentValidation;
 
 using Toast.Common.Exceptions;
 using Toast.Sms.Models;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 
 namespace Toast.Sms.Validators
 {
@@ -48,7 +49,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = (regex == null) ? new RegexDateTimeWrapper() : regex ;
+            this._regex = regex.ThrowIfNullOrDefault();
 
             this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
             this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -45,10 +45,10 @@ namespace Toast.Sms.Validators
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessageStatusRequestQueryValidator"/> class.
         /// </summary>
-        public ListMessageStatusRequestQueryValidator()
+        public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
         {
-            this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
-            this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);
+            this.RuleFor(p => p.StartUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty();
+            this.RuleFor(p => p.EndUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty().GreaterThan(q => q.StartUpdateDate);
             When(p => p.MessageType != null, () =>
             {
                 this.RuleFor(p => p.MessageType).Must(p => MsgType.Contains(p));
@@ -58,17 +58,5 @@ namespace Toast.Sms.Validators
 
         }
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };
-
-        private bool IsValidDateFormat(string date)
-        {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
-            }   
-        }
     }
 }

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -64,7 +64,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return (date != null) ? _regex.IsMatch(date) : false;
+            return _regex.IsMatch(date);
         }
 
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -48,7 +48,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex;
+            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
 
             this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
             this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);
@@ -63,14 +63,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return this._regex.IsMatch(date);
-            }
+            return date != null ? _regex.IsMatch(date) : false ;
         }
         
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };

--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -64,9 +64,9 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return (date != null) ? _regex.IsMatch(date) : false ;
+            return (date != null) ? _regex.IsMatch(date) : false;
         }
-        
+
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };
     }
 }

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -63,7 +63,7 @@ namespace Toast.Sms.Validators
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessagesRequestQueryValidator"/> class.
         /// </summary>
-        public ListMessagesRequestQueryValidator()
+        public ListMessagesRequestQueryValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
         {
 
             this.RuleFor(p => p.RequestId)
@@ -74,16 +74,17 @@ namespace Toast.Sms.Validators
                 .When(p => p.StartCreateDate == null)
                 .When(p => p.EndCreateDate == null);
 
+
             this.RuleFor(p => p.StartRequestDate)
                 .NotEmpty()
-                .Must(IsValidDateFormat)
+                .Must(iRegexDateTimeWrapper.IsMatch)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartCreateDate == null)
                 .When(p => p.EndCreateDate == null);
 
             this.RuleFor(p => p.EndRequestDate)
                 .NotEmpty()
-                .Must(IsValidDateFormat)
+                .Must(iRegexDateTimeWrapper.IsMatch)
                 .GreaterThan(p => p.StartRequestDate)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartCreateDate == null)
@@ -91,22 +92,22 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.StartCreateDate)
                 .NotEmpty()
-                .Must(IsValidDateFormat)
+                .Must(iRegexDateTimeWrapper.IsMatch)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartRequestDate == null)
                 .When(p => p.EndRequestDate == null);
 
             this.RuleFor(p => p.EndCreateDate)
                 .NotEmpty()
-                .Must(IsValidDateFormat)
+                .Must(iRegexDateTimeWrapper.IsMatch)
                 .GreaterThan(p => p.StartCreateDate)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartRequestDate == null)
                 .When(p => p.EndRequestDate == null);
 
-            this.RuleFor(p => p.StartResultDate).Must(IsValidDateFormat).When(p => p.StartResultDate != null);
+            this.RuleFor(p => p.StartResultDate).Must(iRegexDateTimeWrapper.IsMatch).When(p => p.StartResultDate != null);
 
-            this.RuleFor(p => p.EndResultDate).Must(IsValidDateFormat).GreaterThan(p => p.StartResultDate).When(p => p.EndResultDate != null);
+            this.RuleFor(p => p.EndResultDate).Must(iRegexDateTimeWrapper.IsMatch).GreaterThan(p => p.StartResultDate).When(p => p.EndResultDate != null);
 
             this.RuleFor(p => p.SendNumber).MaximumLength(13);
 
@@ -134,16 +135,6 @@ namespace Toast.Sms.Validators
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };
         List<string> resultCodeType = new List<string>() { "MTR1", "MTR2" };
         List<string> subResultCodeType = new List<string>() { "MTR2_1", "MTR2_2", "MTR2_3" };
-        private bool IsValidDateFormat(string date)
-        {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
-            }
-        }
+
     }
 }

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -39,11 +39,13 @@ namespace Toast.Sms.Validators
 
     public class ListMessagesRequestQueryValidator : AbstractValidator<ListMessagesRequestQueries>
     {
+        private readonly IRegexDateTimeWrapper _regex;
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessagesRequestQueryValidator"/> class.
         /// </summary>
-        public ListMessagesRequestQueryValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
+        public ListMessagesRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
+            this._regex = regex;
 
             this.RuleFor(p => p.RequestId)
                 .NotEmpty()
@@ -56,14 +58,14 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.StartRequestDate)
                 .NotEmpty()
-                .Must(iRegexDateTimeWrapper.IsMatch)
+                .Must(IsValidDateFormat)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartCreateDate == null)
                 .When(p => p.EndCreateDate == null);
 
             this.RuleFor(p => p.EndRequestDate)
                 .NotEmpty()
-                .Must(iRegexDateTimeWrapper.IsMatch)
+                .Must(IsValidDateFormat)
                 .GreaterThan(p => p.StartRequestDate)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartCreateDate == null)
@@ -71,22 +73,22 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.StartCreateDate)
                 .NotEmpty()
-                .Must(iRegexDateTimeWrapper.IsMatch)
+                .Must(IsValidDateFormat)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartRequestDate == null)
                 .When(p => p.EndRequestDate == null);
 
             this.RuleFor(p => p.EndCreateDate)
                 .NotEmpty()
-                .Must(iRegexDateTimeWrapper.IsMatch)
+                .Must(IsValidDateFormat)
                 .GreaterThan(p => p.StartCreateDate)
                 .When(p => p.RequestId == null)
                 .When(p => p.StartRequestDate == null)
                 .When(p => p.EndRequestDate == null);
 
-            this.RuleFor(p => p.StartResultDate).Must(iRegexDateTimeWrapper.IsMatch).When(p => p.StartResultDate != null);
+            this.RuleFor(p => p.StartResultDate).Must(IsValidDateFormat).When(p => p.StartResultDate != null);
 
-            this.RuleFor(p => p.EndResultDate).Must(iRegexDateTimeWrapper.IsMatch).GreaterThan(p => p.StartResultDate).When(p => p.EndResultDate != null);
+            this.RuleFor(p => p.EndResultDate).Must(IsValidDateFormat).GreaterThan(p => p.StartResultDate).When(p => p.EndResultDate != null);
 
             this.RuleFor(p => p.SendNumber).MaximumLength(13);
 
@@ -107,6 +109,18 @@ namespace Toast.Sms.Validators
             this.RuleFor(p => p.PageNumber).GreaterThan(0);
 
             this.RuleFor(p => p.PageSize).GreaterThan(0);
+        }
+
+        private bool IsValidDateFormat(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return this._regex.IsMatch(date);
+            }
         }
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -45,7 +45,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         public ListMessagesRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex;
+            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
 
             this.RuleFor(p => p.RequestId)
                 .NotEmpty()
@@ -113,14 +113,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return this._regex.IsMatch(date);
-            }
+            return date != null ? _regex.IsMatch(date) : false ;
         }
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -113,7 +113,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return (date != null) ? _regex.IsMatch(date) : false ;
+            return _regex.IsMatch(date);
         }
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -142,7 +142,10 @@ namespace Toast.Sms.Validators
             }
             else
             {
-                return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+                RegexDateTimeWrapper singleTone = new RegexDateTimeWrapper();
+
+                //return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+                return singleTone.IsMatch(date);
             }
         }
     }

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -113,7 +113,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return date != null ? _regex.IsMatch(date) : false ;
+            return (date != null) ? _regex.IsMatch(date) : false ;
         }
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -60,6 +60,7 @@ namespace Toast.Sms.Validators
     }
     public class ListMessagesRequestQueryValidator : AbstractValidator<ListMessagesRequestQueries>
     {
+        RegexDateTimeWrapper singleTone = new RegexDateTimeWrapper();
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessagesRequestQueryValidator"/> class.
         /// </summary>
@@ -142,7 +143,6 @@ namespace Toast.Sms.Validators
             }
             else
             {
-                RegexDateTimeWrapper singleTone = new RegexDateTimeWrapper();
 
                 //return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
                 return singleTone.IsMatch(date);

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -36,6 +36,28 @@ namespace Toast.Sms.Validators
             throw new RequestQueryNotValidException("Invalid Query Parameter") { StatusCode = HttpStatusCode.BadRequest };
         }
     }
+
+    public interface IRegexDateTimeWrapper
+    {
+        bool IsMatch(string date);
+    }
+
+    public class RegexDateTimeWrapper : IRegexDateTimeWrapper
+    {
+        private static Regex regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+
+        public bool IsMatch(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return regex.IsMatch(date);
+            }
+        }
+    }
     public class ListMessagesRequestQueryValidator : AbstractValidator<ListMessagesRequestQueries>
     {
         /// <summary>
@@ -97,7 +119,7 @@ namespace Toast.Sms.Validators
             this.RuleFor(p => p.ResultCode).MaximumLength(10).Must(p => resultCodeType.Contains(p)).When(p => p.ResultCode != null);
 
             this.RuleFor(p => p.SubResultCode).MaximumLength(10).Must(p => subResultCodeType.Contains(p)).When(p => p.SubResultCode != null);
-            
+
             this.RuleFor(p => p.SenderGroupingKey).MaximumLength(100);
 
             this.RuleFor(p => p.RecipientGroupingKey).MaximumLength(100);
@@ -106,6 +128,8 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.PageSize).GreaterThan(0);
         }
+
+
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };
         List<string> resultCodeType = new List<string>() { "MTR1", "MTR2" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -1,10 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using FluentValidation;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Toast.Common.Exceptions;
 using Toast.Sms.Models;
 
@@ -45,7 +45,7 @@ namespace Toast.Sms.Validators
         /// </summary>
         public ListMessagesRequestQueryValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
+            this._regex = regex.ThrowIfNullOrDefault();
 
             this.RuleFor(p => p.RequestId)
                 .NotEmpty()

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -113,7 +113,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return _regex.IsMatch(date);
+            return this._regex.IsMatch(date);
         }
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -37,27 +37,6 @@ namespace Toast.Sms.Validators
         }
     }
 
-    public interface IRegexDateTimeWrapper
-    {
-        bool IsMatch(string date);
-    }
-
-    public class RegexDateTimeWrapper : IRegexDateTimeWrapper
-    {
-        private static Regex regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
-
-        public bool IsMatch(string date)
-        {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return regex.IsMatch(date);
-            }
-        }
-    }
     public class ListMessagesRequestQueryValidator : AbstractValidator<ListMessagesRequestQueries>
     {
         /// <summary>
@@ -129,8 +108,6 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.PageSize).GreaterThan(0);
         }
-
-
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };
         List<string> resultCodeType = new List<string>() { "MTR1", "MTR2" };

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -23,14 +23,7 @@ namespace Toast.Sms.Validators
         /// <inheritdoc />
         public bool IsMatch(string date)
         {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return _regex.IsMatch(date);
-            }
+            return date != null ? _regex.IsMatch(date) : false ;
         }
     }
 }

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -23,7 +23,7 @@ namespace Toast.Sms.Validators
         /// <inheritdoc />
         public bool IsMatch(string date)
         {
-            if (date == null)
+            if (string.IsNullOrWhiteSpace(date))
             {
                 return false;
             }

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -18,12 +18,19 @@ namespace Toast.Sms.Validators
     /// </summary>
     public class RegexDateTimeWrapper : IRegexDateTimeWrapper
     {
-        private static Regex _regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+        private static Regex regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
 
         /// <inheritdoc />
         public bool IsMatch(string date)
         {
-            return (date != null) ? _regex.IsMatch(date) : false ;
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return regex.IsMatch(date);
+            }
         }
     }
 }

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -23,7 +23,7 @@ namespace Toast.Sms.Validators
         /// <inheritdoc />
         public bool IsMatch(string date)
         {
-            return date != null ? _regex.IsMatch(date) : false ;
+            return (date != null) ? _regex.IsMatch(date) : false ;
         }
     }
 }

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -3,17 +3,24 @@ using System.Text.RegularExpressions;
 namespace Toast.Sms.Validators
 {
     /// <summary>
-    /// This represents the singleton entity of regex for the validators.
+    /// This describes the method that checks validation of format in its contract.
     /// </summary>
     public interface IRegexDateTimeWrapper
     {
+        /// <summary>
+        /// Gets whether the date format is valid or not.
+        /// </summary>
         bool IsMatch(string date);
     }
 
+    /// <summary>
+    /// This represents the singleton entity of regex for the validators.
+    /// </summary>
     public class RegexDateTimeWrapper : IRegexDateTimeWrapper
     {
         private static Regex _regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
 
+        /// <inheritdoc />
         public bool IsMatch(string date)
         {
             if (date == null)

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -27,10 +27,8 @@ namespace Toast.Sms.Validators
             {
                 return false;
             }
-            else
-            {
-                return regex.IsMatch(date);
-            }
+            
+            return regex.IsMatch(date);
         }
     }
 }

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace Toast.Sms.Validators
+{
+    /// <summary>
+    /// This represents the singleton entity of regex for the validators.
+    /// </summary>
+    public interface IRegexDateTimeWrapper
+    {
+        bool IsMatch(string date);
+    }
+
+    public class RegexDateTimeWrapper : IRegexDateTimeWrapper
+    {
+        private static Regex _regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+
+        public bool IsMatch(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return _regex.IsMatch(date);
+            }
+        }
+    }
+}

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -45,7 +45,7 @@ namespace Toast.Sms.Validators
         ///
         public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex;
+            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
 
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);
@@ -59,14 +59,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return this._regex.IsMatch(date);
-            }
+            return date != null ? _regex.IsMatch(date) : false ;
         }
     }
     /// <summary>

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using FluentValidation;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Toast.Common.Exceptions;
 using Toast.Sms.Models;
 
@@ -45,7 +45,7 @@ namespace Toast.Sms.Validators
         ///
         public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = (regex == null) ? new RegexDateTimeWrapper() : regex ;
+            this._regex = regex.ThrowIfNullOrDefault();
 
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -45,7 +45,7 @@ namespace Toast.Sms.Validators
         ///
         public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper regex)
         {
-            this._regex = regex == null ? new RegexDateTimeWrapper() : regex ;
+            this._regex = (regex == null) ? new RegexDateTimeWrapper() : regex ;
 
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);
@@ -59,7 +59,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return date != null ? _regex.IsMatch(date) : false ;
+            return (date != null) ? _regex.IsMatch(date) : false ;
         }
     }
     /// <summary>

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -59,7 +59,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return _regex.IsMatch(date);
+            return this._regex.IsMatch(date);
         }
     }
     /// <summary>

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -42,21 +42,16 @@ namespace Toast.Sms.Validators
         /// Initializes a new instance of the <see cref="SendMessagesRequestBodyValidator"/> class.
         /// </summary>
         ///
-        public SendMessagesRequestBodyValidator()
+        public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
         {
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);
             this.RuleFor(p => p.SenderNumber).NotEmpty().MaximumLength(13);
-            this.RuleFor(p => p.RequestDate).Must(IsValidDateFormat).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
+            this.RuleFor(p => p.RequestDate).Must(iRegexDateTimeWrapper.IsMatch).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
             this.RuleFor(p => p.SenderGroupingKey).MaximumLength(100);
             this.RuleForEach(p => p.Recipients).SetValidator(new SendMessagesRequestRecipientValidator());
             this.RuleFor(p => p.UserId).MaximumLength(100).When(p => p.UserId != null);
             this.RuleFor(p => p.StatsId).MaximumLength(100).When(p => p.StatsId != null);
-        }
-
-        private bool IsValidDateFormat(string date)
-        {
-            return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
         }
     }
     /// <summary>

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -38,20 +38,35 @@ namespace Toast.Sms.Validators
     /// </summary>
     public class SendMessagesRequestBodyValidator : AbstractValidator<SendMessagesRequestBody>
     {
+        private readonly IRegexDateTimeWrapper _regex;
         /// <summary>
         /// Initializes a new instance of the <see cref="SendMessagesRequestBodyValidator"/> class.
         /// </summary>
         ///
-        public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
+        public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper regex)
         {
+            this._regex = regex;
+
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);
             this.RuleFor(p => p.SenderNumber).NotEmpty().MaximumLength(13);
-            this.RuleFor(p => p.RequestDate).Must(iRegexDateTimeWrapper.IsMatch).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
+            this.RuleFor(p => p.RequestDate).Must(IsValidDateFormat).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
             this.RuleFor(p => p.SenderGroupingKey).MaximumLength(100);
             this.RuleForEach(p => p.Recipients).SetValidator(new SendMessagesRequestRecipientValidator());
             this.RuleFor(p => p.UserId).MaximumLength(100).When(p => p.UserId != null);
             this.RuleFor(p => p.StatsId).MaximumLength(100).When(p => p.StatsId != null);
+        }
+
+        private bool IsValidDateFormat(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return this._regex.IsMatch(date);
+            }
         }
     }
     /// <summary>

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -59,7 +59,7 @@ namespace Toast.Sms.Validators
 
         private bool IsValidDateFormat(string date)
         {
-            return (date != null) ? _regex.IsMatch(date) : false ;
+            return _regex.IsMatch(date);
         }
     }
     /// <summary>

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 
 using FluentAssertions;
-using Moq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -66,9 +65,8 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
-            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper);
 
 
             Func<Task> func = async () => await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
@@ -92,9 +90,8 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper);
 
             var result = await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Toast.Sms.Tests.Validators
         [DataTestMethod]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", null, null, null, true)]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", "AUTH", null, null, true)]
-        [DataRow("20220501 00:00:00", "20220501 23:59:59", null, null, null, true)]
+        [DataRow("20220501 00:00:00", "20220501 23:59:59", null, null, null, false)]
         [DataRow("2022-05-01 00:00:00", null, null, null, null, false)]
         [DataRow(null, "2022-05-01 23:59:59", null, null, null, false)]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", null, 0, null, false)]
@@ -37,9 +37,8 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper);
 
             var result = validator.Validate(queries);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Toast.Sms.Tests.Validators
         [DataTestMethod]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", null, null, null, true)]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", "AUTH", null, null, true)]
-        [DataRow("20220501 00:00:00", "20220501 23:59:59", null, null, null, false)]
+        [DataRow("20220501 00:00:00", "20220501 23:59:59", null, null, null, true)]
         [DataRow("2022-05-01 00:00:00", null, null, null, null, false)]
         [DataRow(null, "2022-05-01 23:59:59", null, null, null, false)]
         [DataRow("2022-05-01 00:00:00", "2022-05-01 23:59:59", null, 0, null, false)]
@@ -38,7 +38,7 @@ namespace Toast.Sms.Tests.Validators
             };
 
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
             var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
 
             var result = validator.Validate(queries);

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 
 using FluentAssertions;
+using Moq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -35,9 +36,10 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
+
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
 
             var result = validator.Validate(queries);
 
@@ -65,8 +67,10 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
+
 
             Func<Task> func = async () => await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -88,9 +92,10 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
+
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
 
             var result = await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -38,7 +38,7 @@ namespace Toast.Sms.Tests.Validators
             };
 
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
             var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
 
             var result = validator.Validate(queries);
@@ -68,7 +68,7 @@ namespace Toast.Sms.Tests.Validators
             };
 
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
             var validator = new ListMessageStatusRequestQueryValidator(wrapper.Object);
 
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -35,7 +35,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+            
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(queries);
 
@@ -62,7 +64,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             Func<Task> func = async () => await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -84,7 +88,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+            
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -27,11 +27,11 @@ namespace Toast.Sms.Tests.Validators
         [DataRow(null, null, null, null, "2022-05-11 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, null, "2022-05-11 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow(null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow(null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
+        [DataRow(null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, true)]
+        [DataRow(null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, null, null, true)]
         [DataRow(null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, false)]
+        [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, true)]
         [DataRow("1234567890", null, null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, false)]
 
         public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate,
@@ -59,7 +59,7 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
             var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Moq;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Toast.Common.Exceptions;
@@ -56,9 +58,10 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(queries);
 
@@ -108,8 +111,9 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
             Func<Task> func = async () => await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -146,8 +150,9 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
             var result = await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -32,8 +32,8 @@ namespace Toast.Sms.Tests.Validators
         [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow("1234567890", null, null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, false)]
 
-        public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate, 
-            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode, 
+        public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate,
+            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode,
             string SenderGroupingKey, string recipientGroupingkey, int? pageNum, int? pageSize, bool expected)
         {
             var queries = new ListMessagesRequestQueries()
@@ -56,7 +56,8 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var validator = new ListMessagesRequestQueryValidator();
+            var RegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(queries);
 
@@ -81,8 +82,8 @@ namespace Toast.Sms.Tests.Validators
         [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null)]
         [DataRow("1234567890", null, null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null)]
 
-        public void Given_InvalidValues_When_Validate_Invoked_Then_It_Should_Throw_Exception(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate, 
-            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode, 
+        public void Given_InvalidValues_When_Validate_Invoked_Then_It_Should_Throw_Exception(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate,
+            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode,
             string SenderGroupingKey, string recipientGroupingkey, int? pageNum, int? pageSize)
         {
             var queries = new ListMessagesRequestQueries()
@@ -117,8 +118,8 @@ namespace Toast.Sms.Tests.Validators
         [DataRow("1234567890", "2022-05-10 00:00:00", "2022-05-11 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, 15)]
         [DataRow("1234567890", "2022-05-10 00:00:00", "2022-05-11 00:00:00", "2022-05-10 00:00:00", "2022-05-11 00:00:00", "2022-05-10 00:00:00", "2022-05-11 00:00:00", "1234567890", "1234567890", "1234567890", "2", "MTR1", "MTR2_1", "1234567890", "1234567890", null, null, 1, 15)]
 
-        public async Task Given_ValidValues_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate, 
-            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode, 
+        public async Task Given_ValidValues_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate,
+            string startResultDate, string endResultDate, string sendNumber, string recipientNumber, string templateId, string msgStatus, string resultCode, string subResultCode,
             string SenderGroupingKey, string recipientGroupingkey, int? pageNum, int? pageSize, int expectedPageNumber, int expectedPageSize)
         {
             var queries = new ListMessagesRequestQueries()
@@ -141,7 +142,7 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var validator = new ListMessagesRequestQueryValidator();
+            var validator = new ListMessagesRequestQueryValidator(queries);
 
             var result = await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -27,11 +27,11 @@ namespace Toast.Sms.Tests.Validators
         [DataRow(null, null, null, null, "2022-05-11 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, null, "2022-05-11 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow(null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, true)]
-        [DataRow(null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, null, null, true)]
+        [DataRow(null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, false)]
+        [DataRow(null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow(null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)]
-        [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, true)]
+        [DataRow("1234567890", null, null, null, null, "20220510000000", "20220511000000", null, null, null, null, null, null, null, null, null, null, false)]
         [DataRow("1234567890", null, null, null, null, "2022-05-11 00:00:00", "2022-05-10 00:00:00", null, null, null, null, null, null, null, null, null, null, false)]
 
         public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string requestId, string startRequestDate, string endRequestDate, string startCreateDate, string endCreateDate,
@@ -58,9 +58,8 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(wrapper);
 
 
             var result = validator.Validate(queries);

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -56,7 +56,8 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var RegexDateTimeWrapper = new RegexDateTimeWrapper();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
             var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(queries);
@@ -106,7 +107,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var validator = new ListMessagesRequestQueryValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
 
             Func<Task> func = async () => await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -142,7 +145,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-            var validator = new ListMessagesRequestQueryValidator(queries);
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -59,7 +59,7 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
             var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
 
@@ -112,7 +112,7 @@ namespace Toast.Sms.Tests.Validators
             };
 
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
             var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
 
             Func<Task> func = async () => await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);

--- a/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessagesRequestQueryValidatorTests.cs
@@ -3,8 +3,6 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
-using Moq;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Toast.Common.Exceptions;
@@ -110,9 +108,8 @@ namespace Toast.Sms.Tests.Validators
                 PageSize = pageSize
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
-            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(wrapper);
 
             Func<Task> func = async () => await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -148,10 +145,8 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNum,
                 PageSize = pageSize
             };
-
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new ListMessagesRequestQueryValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessagesRequestQueryValidator(wrapper);
 
             var result = await ListMessagesQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
@@ -14,7 +14,8 @@ namespace Toast.Sms.Tests.Validators
     {
         [DataTestMethod]
         [DataRow("2022-05-01 00:00:00", true)]
-        [DataRow("2022-05-01 00:00:00", true)]
+        [DataRow("0111-09-01 00:00:00", true)]
+        [DataRow("9999-09-01 00:00:00", true)]
         [DataRow("20220501 00:00:00", false)]
         [DataRow("2022-08-90 55:00:00", false)]
         [DataRow("2022-0&-OO 00:oo:OT", false)]

--- a/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
@@ -16,6 +16,7 @@ namespace Toast.Sms.Tests.Validators
         [DataRow("2022-05-01 00:00:00", true)]
         [DataRow("0111-09-01 00:00:00", true)]
         [DataRow("9999-09-01 00:00:00", true)]
+        [DataRow("9999-15-41 00:00:00", false)]
         [DataRow("20220501 00:00:00", false)]
         [DataRow("2022-08-90 55:00:00", false)]
         [DataRow("2022-0&-OO 00:oo:OT", false)]

--- a/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Toast.Sms.Validators;
+
+namespace Toast.Sms.Tests.Validators
+{
+    [TestClass]
+    public class RegexDateTimeWrapperTests
+    {
+        [DataTestMethod]
+        [DataRow("2022-05-01 00:00:00", true)]
+        [DataRow("2022-05-01 00:00:00", true)]
+        [DataRow("20220501 00:00:00", false)]
+        [DataRow("2022-08-90 55:00:00", false)]
+        [DataRow("2022-0&-OO 00:oo:OT", false)]
+        public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string date, bool expected)
+        {
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+
+            var result = iRegexDateTimeWrapper.IsMatch(date).Should().Be(expected);
+        }
+
+    }
+}

--- a/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
@@ -22,9 +22,14 @@ namespace Toast.Sms.Tests.Validators
         [DataRow("2022-0&-OO 00:oo:OT", false)]
         public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string date, bool expected)
         {
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            //Arrange
+            var wapper = new RegexDateTimeWrapper();
 
-            var result = iRegexDateTimeWrapper.IsMatch(date).Should().Be(expected);
+            //Act
+            var result = wapper.IsMatch(date);
+
+            //Assert
+            result.Should().Be(expected);
         }
 
     }

--- a/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/RegexDateTimeWrapperTests.cs
@@ -30,6 +30,7 @@ namespace Toast.Sms.Tests.Validators
 
             //Assert
             result.Should().Be(expected);
+
         }
 
     }

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -22,7 +22,7 @@ namespace Toast.Sms.Tests.Validators
         [DataRow(null, "Hello world", "1234567890", "2022-05-10 00:00:00", null, null, null, null, null, null, null, false)]
         [DataRow(null, "Hello world", null, "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, null, "1234567890", "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
-        [DataRow(null, "Hello world", "1234567890", "2022051000000", null, "0987654321", null, null, null, null, null, true)]
+        [DataRow(null, "Hello world", "1234567890", "2022051000000", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, "Hello world", "12345678901234567890", "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, "Hello world", "1234567890", "2022-05-10 00:00:00", null, "098765432109876543210987654321", null, null, null, null, null, false)]
         public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string templateId, string body, string sendNo, string requestDate, string senderGroupingKey,
@@ -50,9 +50,8 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(wrapper);
 
             var result = validator.Validate(payloads);
 

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -6,8 +6,6 @@ using FluentAssertions;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
-
 using Toast.Common.Exceptions;
 using Toast.Sms.Models;
 using Toast.Sms.Validators;
@@ -92,9 +90,8 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
-            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(wrapper);
 
             Func<Task> func = async () => await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 
@@ -133,9 +130,8 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
 
-            var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
-            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
+            var wrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(wrapper);
 
             var result = await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -22,7 +22,7 @@ namespace Toast.Sms.Tests.Validators
         [DataRow(null, "Hello world", "1234567890", "2022-05-10 00:00:00", null, null, null, null, null, null, null, false)]
         [DataRow(null, "Hello world", null, "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, null, "1234567890", "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
-        [DataRow(null, "Hello world", "1234567890", "2022051000000", null, "0987654321", null, null, null, null, null, false)]
+        [DataRow(null, "Hello world", "1234567890", "2022051000000", null, "0987654321", null, null, null, null, null, true)]
         [DataRow(null, "Hello world", "12345678901234567890", "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, "Hello world", "1234567890", "2022-05-10 00:00:00", null, "098765432109876543210987654321", null, null, null, null, null, false)]
         public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string templateId, string body, string sendNo, string requestDate, string senderGroupingKey,
@@ -51,7 +51,7 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
             var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             var result = validator.Validate(payloads);

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -51,7 +51,7 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(expected);
             var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             var result = validator.Validate(payloads);
@@ -94,7 +94,7 @@ namespace Toast.Sms.Tests.Validators
             };
 
             var wrapper = new Mock<IRegexDateTimeWrapper>();
-            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(false);
             var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             Func<Task> func = async () => await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -48,7 +48,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(payloads);
 
@@ -88,7 +90,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             Func<Task> func = async () => await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 
@@ -126,7 +130,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             var result = await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -6,6 +6,8 @@ using FluentAssertions;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Moq;
+
 using Toast.Common.Exceptions;
 using Toast.Sms.Models;
 using Toast.Sms.Validators;
@@ -23,7 +25,7 @@ namespace Toast.Sms.Tests.Validators
         [DataRow(null, "Hello world", "1234567890", "2022051000000", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, "Hello world", "12345678901234567890", "2022-05-10 00:00:00", null, "0987654321", null, null, null, null, null, false)]
         [DataRow(null, "Hello world", "1234567890", "2022-05-10 00:00:00", null, "098765432109876543210987654321", null, null, null, null, null, false)]
-        public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string templateId, string body, string sendNo, string requestDate, string senderGroupingKey, 
+        public void Given_Values_When_Validate_Invoked_Then_It_Should_Return_Result(string templateId, string body, string sendNo, string requestDate, string senderGroupingKey,
             string recipientNo, string countryCode, string InternationalRecipientNo, string recipientGroupingKey, string userId, string statsId, bool expected)
         {
             var recipient = new SendMessagesRequestRecipient()
@@ -48,9 +50,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             var result = validator.Validate(payloads);
 
@@ -91,8 +93,9 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             Func<Task> func = async () => await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 
@@ -131,8 +134,9 @@ namespace Toast.Sms.Tests.Validators
                 StatsId = statsId
             };
 
-            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
-            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
+            var wrapper = new Mock<IRegexDateTimeWrapper>();
+            wrapper.Setup(p => p.IsMatch(It.IsAny<string>())).Returns(true);
+            var validator = new SendMessagesRequestBodyValidator(wrapper.Object);
 
             var result = await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 


### PR DESCRIPTION
관련 이슈: [Validator 클라스 안의 Regex 의존성 수정하기 #70 ](https://github.com/devrel-kr/nhn-toast-notification-service-custom-connector/issues/70)
작업 사항: nt-sms 내부 Validator 클래스에 있는 Regex 객체들을 싱글톤으로 구조 변경하여 개별 클래스와 인터페이스로 분리하고 해당 Regex 객체 바탕으로 Validator의 Regex 의존성 수정