### PR TITLE
Add HttpTriggerWorkflow ValidateQueries

### DIFF
--- a/src/nt-sms/Startup.cs
+++ b/src/nt-sms/Startup.cs
@@ -9,6 +9,7 @@ using Toast.Common.Configurations;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
 using Toast.Sms.Validators;
+using Toast.Sms.Workflows;
 
 [assembly: FunctionsStartup(typeof(Toast.Sms.Startup))]
 
@@ -28,6 +29,7 @@ namespace Toast.Sms
         {
             ConfigureAppSettings(builder.Services);
             ConfigureHttpClient(builder.Services);
+            ConfigureWorkflows(builder.Services);
             ConfigureValidators(builder.Services);
         }
 
@@ -42,6 +44,11 @@ namespace Toast.Sms
         private static void ConfigureHttpClient(IServiceCollection services)
         {
             services.AddHttpClient("messages");
+        }
+
+        private static void ConfigureWorkflows(IServiceCollection services)
+        {
+            services.AddScoped<IHttpTriggerWorkflow, HttpTriggerWorkflow>();
         }
 
         private static void ConfigureValidators(IServiceCollection services)

--- a/src/nt-sms/Validators/RequestQueryValidatorExtensions.cs
+++ b/src/nt-sms/Validators/RequestQueryValidatorExtensions.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+
+using FluentValidation;
+
+using Toast.Common.Models;
+
+namespace Toast.Common.Validators
+{
+    /// <summary>
+    /// This represents the extension entity for request queries validator.
+    /// </summary>
+    public static class RequestQueriesValidatorExtensions
+    {
+        /// <summary>
+        /// Validates request queries.
+        /// </summary>
+        /// <typeparam name="T">Type of request queries instance.</typeparam>
+        /// <param name="queries">Request queries instance.</param>
+        /// <param name="validator"><see cref="IValidator{T}"/> instance.</param>
+        /// <returns>Returns the validated instance.</returns>
+        public static async Task<T> Validate<T>(this Task<T> queries, IValidator<T> validator) where T : BaseRequestQueries
+        {
+            return await queries.Validate(validator).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
+++ b/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+
+using Aliencube.AzureFunctions.Extensions.Common;
+
+using FluentValidation;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+
+using Newtonsoft.Json;
+
+using Toast.Common.Builders;
+using Toast.Common.Configurations;
+using Toast.Common.Extensions;
+using Toast.Common.Models;
+using Toast.Common.Validators;
+using Toast.Sms.Validators;
+
+namespace Toast.Sms.Workflows
+{
+    /// <summary>
+    /// This provides interface to the HTTP trigger workflows.
+    /// </summary>
+    public interface IHttpTriggerWorkflow
+    {
+        /// <summary>
+        /// Validates the request queries.
+        /// </summary>
+        /// <typeparam name="T">Type of the request query object.</typeparam>
+        /// <param name="req"><see cref="HttpRequest"/> instance.</param>
+        /// <param name="validator"><see cref="IValidator{T}"/> instance.</param>
+        /// <returns>Returns the <see cref="IHttpTriggerWorkflow"/> instance.</returns>
+        Task<IHttpTriggerWorkflow> ValidateQueriesAsync<T>(HttpRequest req, IValidator<T> validator) where T : BaseRequestQueries;
+    }
+
+    /// <summary>
+    /// This represents the workflow entity for the HTTP triggers.
+    /// </summary>
+    public class HttpTriggerWorkflow : IHttpTriggerWorkflow
+    {
+        private readonly HttpClient _http;
+
+        private BaseRequestQueries _queries;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpTriggerWorkflow"/> class.
+        /// </summary>
+        /// <param name="factory"><see cref="IHttpClientFactory"/> instance.</param>
+        public HttpTriggerWorkflow(IHttpClientFactory factory)
+        {
+            this._http = factory.ThrowIfNullOrDefault().CreateClient("messages");
+        }
+
+        /// <inheritdoc />
+        public async Task<IHttpTriggerWorkflow> ValidateQueriesAsync<T>(HttpRequest req, IValidator<T> validator) where T : BaseRequestQueries
+        {
+            var queries = await req.To<T>(SourceFrom.Query)
+                                   .Validate(validator)
+                                   .ConfigureAwait(false);
+
+            this._queries = queries;
+
+            return await Task.FromResult(this).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// This represents the extension class for <see cref="IHttpTriggerWorkflow"/>.
+    /// </summary>
+    public static class HttpTriggerWorkflowExtensions
+    {
+        /// <summary>
+        /// Validates the request queries.
+        /// </summary>
+        /// <typeparam name="T">Type of the request query object.</typeparam>
+        /// <param name="workflow"><see cref="IHttpTriggerWorkflow"/> instance wrapped with <see cref="Task"/>.</param>
+        /// <param name="req"><see cref="HttpRequest"/> instance.</param>
+        /// <param name="validator"><see cref="IValidator{T}"/> instance.</param>
+        /// <returns>Returns the <see cref="IHttpTriggerWorkflow"/> instance.</returns>
+        public static async Task<IHttpTriggerWorkflow> ValidateQueriesAsync<T>(this Task<IHttpTriggerWorkflow> workflow, HttpRequest req, IValidator<T> validator) where T : BaseRequestQueries
+        {
+            var instance = await workflow.ConfigureAwait(false);
+
+            return await instance.ValidateQueriesAsync(req, validator);
+        }
+    }
+}

--- a/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTests.cs
+++ b/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Net.Mime;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Aliencube.AzureFunctions.Extensions.Common;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+using Toast.Common.Configurations;
+using Toast.Common.Exceptions;
+using Toast.Common.Models;
+//using Toast.Tests.Common.Fakes;
+using Toast.Sms.Configurations;
+using Toast.Sms.Triggers;
+using Toast.Sms.Workflows;
+using Toast.Sms.Models;
+using System.Net.Http;
+using FluentValidation;
+
+using WorldDomination.Net.Http;
+using Toast.Tests.Common.Configurations;
+using Toast.Sms.Tests.Configurations;
+using Toast.Common.Builders;
+
+namespace Toast.Sms.Tests.Workflows
+{
+    [TestClass]
+    public class HttpTriggerWorkflowTests
+
+    {
+
+        private Mock<IHttpClientFactory> _factory;
+
+         [TestInitialize]
+        public void Init()
+        {
+            this._factory = new Mock<IHttpClientFactory>();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this._factory = null;
+
+        }
+        [TestMethod]
+        public void Given_Type_When_Initiated_Then_It_Should_Implement_Interface()
+        {
+            var workflow = new HttpTriggerWorkflow(this._factory.Object);
+
+            var hasInterface = workflow.GetType().HasInterface<IHttpTriggerWorkflow>();
+
+            hasInterface.Should().BeTrue();
+        }
+        
+        /*
+        //쿼리 예외 테스트
+        [TestMethod]
+        public void Given_ValidQueries_fails_When_Invoke_ValidateQueriesAsync_Then_It_Should_Throw_Exception()
+        {
+            var queries = new QueryCollection();
+            
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Query).Returns(queries);
+            
+            var validator = new Mock<IValidator<GetMessageRequestQueries>>();
+            var workflow = new HttpTriggerWorkflow(this._factory.Object);
+            Func<Task> func = async () => await workflow.ValidateQueriesAsync<GetMessageRequestQueries>(req.Object, validator.Object);
+
+            func.Should().ThrowAsync<RequestQueryNotValidException>();
+        }
+
+        //쿼리 테스트
+        [DataTestMethod]
+        [DataRow("Hello","world")]
+        public async Task Given_ValidQueries_When_Invoke_ValidateQueriesAsync_Then_It_Should_Return_Result(string name, string value)
+        {
+
+            var queries = new QueryCollection();
+
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Query).Returns(queries);
+
+            var validator = new Mock<IValidator<GetMessageRequestQueries>>();
+            var workflow = new HttpTriggerWorkflow(this._factory.Object);
+
+            await workflow.ValidateQueriesAsync<GetMessageRequestQueries>(req.Object, validator.Object);
+
+            var fi = workflow.GetType().GetField("_queries", BindingFlags.NonPublic | BindingFlags.Instance);
+            var result = (GetMessageRequestQueries)fi.GetValue(workflow);
+
+            result.Should().BeOfType<GetMessageRequestQueries>();
+
+            //result.PropertyA.Should().Be(expected);
+        }             
+        */
+
+    }
+}


### PR DESCRIPTION
관련 이슈 : [엔드포인트 리팩토링 #63](https://github.com/devrel-kr/nhn-toast-notification-service-custom-connector/issues/63)
작업 사항 : nt-sms 내부의 Triggers 폴더에 있는 엔드포인트들의 동일한 워크플로우를 가진 Query 메소드를 하나의 서비스 레이어를 생성하여 Fluent API 형태로 리팩토링