### PR TITLE
Add HttpTriggerWorflow BuildRequestUrl

### DIFF
--- a/src/nt-common/Builders/RequestUrlBuilder.cs
+++ b/src/nt-common/Builders/RequestUrlBuilder.cs
@@ -28,6 +28,11 @@ namespace Toast.Common.Builders
         /// <returns>Returns the <see cref="RequestUrlBuilder"/> instance.</returns>
         public RequestUrlBuilder WithSettings<T>(T settings, string endpoint) where T : ToastSettings
         {
+            if (settings == null || string.IsNullOrWhiteSpace(settings.BaseUrl))
+            {
+                throw new InvalidOperationException("Invalid ToastSettings.");   
+            }
+
             this._settings = settings;
             this._endpoint = endpoint;
 

--- a/src/nt-sms/Startup.cs
+++ b/src/nt-sms/Startup.cs
@@ -9,6 +9,7 @@ using Toast.Common.Configurations;
 using Toast.Sms.Configurations;
 using Toast.Sms.Models;
 using Toast.Sms.Validators;
+using Toast.Sms.Workflows;
 
 [assembly: FunctionsStartup(typeof(Toast.Sms.Startup))]
 
@@ -28,6 +29,7 @@ namespace Toast.Sms
         {
             ConfigureAppSettings(builder.Services);
             ConfigureHttpClient(builder.Services);
+            ConfigureWorkflows(builder.Services);
             ConfigureValidators(builder.Services);
         }
 
@@ -42,6 +44,11 @@ namespace Toast.Sms
         private static void ConfigureHttpClient(IServiceCollection services)
         {
             services.AddHttpClient("messages");
+        }
+
+        public static void ConfigureWorkflows(IServiceCollection services)
+        {
+            services.AddSingleton<IHttpTriggerWorkflow, HttpTriggerWorkflow>();
         }
 
         private static void ConfigureValidators(IServiceCollection services)

--- a/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
+++ b/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+
+using Aliencube.AzureFunctions.Extensions.Common;
+
+using FluentValidation;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+
+using Newtonsoft.Json;
+
+using Toast.Common.Builders;
+using Toast.Common.Configurations;
+using Toast.Common.Extensions;
+using Toast.Common.Models;
+using Toast.Common.Validators;
+using Toast.Sms.Validators;
+
+namespace Toast.Sms.Workflows{
+    /// <summary>
+    /// This provides interface to the HTTP trigger workflows.
+    /// </summary>
+    public interface IHttpTriggerWorkflow{
+        /// <summary>
+        /// Validates the request header.
+        /// </summary>
+        /// <param name="req"><see cref="HttpRequest"/> instance.</param>
+        /// <returns>Returns the <see cref="IHttpTriggerWorkflow"/> instance.</returns>
+        Task<IHttpTriggerWorkflow> ValidateHeaderAsync(HttpRequest req);
+
+    }
+
+    /// <inheritdoc />
+    public class HttpTriggerWorkflow : IHttpTriggerWorkflow{
+        private readonly HttpClient _http;
+        private RequestHeaderModel _headers;
+        private readonly MediaTypeFormatter _formatter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpTriggerWorkflow"/> class.
+        /// </summary>
+        /// <param name="factory"><see cref="IHttpClientFactory"/> instance.</param>
+        public HttpTriggerWorkflow(IHttpClientFactory factory, MediaTypeFormatter formatter)
+        {
+            this._http = factory.ThrowIfNullOrDefault().CreateClient("messages");
+            this._formatter = formatter.ThrowIfNullOrDefault();
+        }
+        
+        
+        /// <inheritdoc />
+        public async Task<IHttpTriggerWorkflow> ValidateHeaderAsync(HttpRequest req)
+        {
+            var headers = req.To<RequestHeaderModel>(useBasicAuthHeader: true)
+                             .Validate();
+
+            this._headers = headers;
+
+            return await Task.FromResult(this).ConfigureAwait(false);
+        }
+    }
+
+     /// <summary>
+    /// This represents the extension class for <see cref="IHttpTriggerWorkflow"/>.
+    /// </summary>
+    public static class HttpTriggerWorkflowExtensions
+    {
+       
+    }
+}

--- a/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTest.cs
+++ b/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTest.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Toast.Common.Exceptions;
+using Toast.Common.Models;
+using Toast.Sms.Workflows;
+
+namespace Toast.Sms.Tests.Workflows
+{
+    [TestClass]
+    public class HttpTriggerWorkflowTests{
+        private Mock<IHttpClientFactory> _factory;
+        private Mock<MediaTypeFormatter> _fomatter;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this._factory = new Mock<IHttpClientFactory>();
+            this._fomatter = new Mock<MediaTypeFormatter>();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this._factory = null;
+            this._fomatter = null;
+        }
+        [TestMethod]
+        public void Given_Type_When_Initiated_Then_It_Should_Implement_Interface()
+        {
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            var hasInterface = workflow.GetType().HasInterface<IHttpTriggerWorkflow>();
+
+            hasInterface.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task Given_NullHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_NullReferenceException()
+        {
+            var req = new Mock<HttpRequest>();
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            Func<Task> func = async () => await workflow.ValidateHeaderAsync(req.Object);
+
+            await func.Should().ThrowAsync<NullReferenceException>();
+        }
+
+        [TestMethod]
+        public async Task Given_NoHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_InvalidOperationException()
+        {
+            var headers = new HeaderDictionary();
+            headers.Add("Authorization", "Basic");
+
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Headers).Returns(headers);
+
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            Func<Task> func = async () => await workflow.ValidateHeaderAsync(req.Object);
+
+            await func.Should().ThrowAsync<InvalidOperationException>();
+
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", " ")]
+        [DataRow(" ", "world")]
+        public async Task Given_InvalidHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_Exception(string username, string password)
+        {
+            var bytes = Encoding.UTF8.GetBytes($"{username}:{password}");
+            var encoded = Convert.ToBase64String(bytes);
+
+            var headers = new HeaderDictionary();
+            headers.Add("Authorization", $"Basic {encoded}");
+
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Headers).Returns(headers);
+
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            Func<Task> func = async () => await workflow.ValidateHeaderAsync(req.Object);
+
+            await func.Should().ThrowAsync<RequestHeaderNotValidException>();
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", "world")]
+        public async Task Given_ValidHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Return_Result(string username, string password)
+        {
+            var bytes = Encoding.UTF8.GetBytes($"{username}:{password}");
+            var encoded = Convert.ToBase64String(bytes);
+
+            var headers = new HeaderDictionary();
+            headers.Add("Authorization", $"Basic {encoded}");
+
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Headers).Returns(headers);
+
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            var result = await workflow.ValidateHeaderAsync(req.Object);
+
+            result.Should().BeOfType<HttpTriggerWorkflow>();
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", "world")]
+        public async Task Given_ValidHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Contain_Headers(string username, string password)
+        {
+            var bytes = Encoding.UTF8.GetBytes($"{username}:{password}");
+            var encoded = Convert.ToBase64String(bytes);
+
+            var headers = new HeaderDictionary();
+            headers.Add("Authorization", $"Basic {encoded}");
+
+            var req = new Mock<HttpRequest>();
+            req.SetupGet(p => p.Headers).Returns(headers);
+
+            var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
+
+            var result = await workflow.ValidateHeaderAsync(req.Object);
+            var fi = workflow.GetType().GetField("_headers", BindingFlags.NonPublic | BindingFlags.Instance);
+            var field = fi.GetValue(result) as RequestHeaderModel;
+
+            field.Should().NotBeNull();
+            field.AppKey.Should().Be(username);
+            field.SecretKey.Should().Be(password);
+        }
+    }
+}

--- a/test/NhnToast.Tests.Common/Fakes/FakeEndpointSettings.cs
+++ b/test/NhnToast.Tests.Common/Fakes/FakeEndpointSettings.cs
@@ -1,0 +1,9 @@
+using Toast.Common.Configurations;
+
+namespace Toast.Tests.Common.Fakes
+{
+    public class FakeEndpointSettings : ToastSettings
+    {
+        
+    }
+}

--- a/test/NhnToast.Tests.Common/Fakes/FakeRequestQueries.cs
+++ b/test/NhnToast.Tests.Common/Fakes/FakeRequestQueries.cs
@@ -1,0 +1,10 @@
+using Toast.Common.Models;
+
+namespace Toast.Tests.Common.Fakes
+{
+    public class FakeRequestQueries : BaseRequestQueries
+    {
+        public string FakeQuery1 { get; set; }
+        public string FakeQuery2 { get; set; }
+    }
+}


### PR DESCRIPTION
- BuildRequestUrl 부분 workflow와 테스트 코드 작성 했습니다.
- Test코드를 위한 FakeRequestQueries와 FakeEndpoints 클래스 추가했습니다. 
- NoSetting일 때 Build가 그대로 되어 RequestUrlBuild 클래스의 WithSettings 메소드에 settings가 null인 경우와 setting이 비어있을 때 InvalidException을 날리는 코드를 추가하였습니다.
```csharp
public RequestUrlBuilder WithSettings<T>(T settings, string endpoint) where T : ToastSettings
        {
            if (settings == null || string.IsNullOrWhiteSpace(settings.BaseUrl))
            {
                throw new InvalidOperationException("Invalid ToastSettings.");   
            }

            this._settings = settings;
            this._endpoint = endpoint;
```